### PR TITLE
Updated rules_rust

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,6 @@ jobs:
             ${{ github.workspace }}/examples/.cache
           key: ${{ runner.os }}-${{ env.cache-name }}
 
-      # TODO: Remove after upstream change is merged and `rules_rust` is updated
-      # https://github.com/bazelbuild/rules_rust/pull/959
-      - name: Bootstrap the binary
-        run: bazel ${BAZEL_STARTUP_FLAGS[@]} sync --only=cargo_bazel_bootstrap          
-
       # Build and Test the code
       - name: Build
         run: bazel ${BAZEL_STARTUP_FLAGS[@]} build //...

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,11 +27,6 @@ jobs:
             ~/.cache/bazel
           key: ${{ runner.os }}-${{ env.cache-name }}
 
-      # TODO: Remove after upstream change is merged and `rules_rust` is updated
-      # https://github.com/bazelbuild/rules_rust/pull/959
-      - name: Bootstrap the binary
-        run: bazel ${BAZEL_STARTUP_FLAGS[@]} sync --only=cargo_bazel_bootstrap
-
       - name: Build docs
         run: bazel ${BAZEL_STARTUP_FLAGS[@]} run //docs:generate
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -7,11 +7,11 @@ def cargo_bazel_deps():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "82b30cbb46c61a9014de0a8d0443a45e6eb6bd9add35ab421cfb1943dc3271f5",
-        strip_prefix = "rules_rust-e589105b4e8181dd1d0d8ccaa0cf3267efb06e86",
+        sha256 = "77ea48f574efac1b05ccd885fd49ac655e139bdad2f6279ce07f59cd3478b33e",
+        strip_prefix = "rules_rust-8d7a3c021e324386519a636d6f5d07ba14743bd0",
         urls = [
-            # `main` branch as of 2021-09-21
-            "https://github.com/bazelbuild/rules_rust/archive/e589105b4e8181dd1d0d8ccaa0cf3267efb06e86.tar.gz",
+            # `main` branch as of 2021-10-11
+            "https://github.com/bazelbuild/rules_rust/archive/8d7a3c021e324386519a636d6f5d07ba14743bd0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This fixes the need to perform `bazel sync` now that `cargo_bootstrap_repository` can appropriately detect changes.