### PR TITLE
Added build to mark GitHub CI as successful

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,3 +82,10 @@ jobs:
           chmod +x buildifier
       - name: Buildifier
         run: ./buildifier -lint=warn -mode=check -warnings=all -r ${{ github.workspace }}
+
+  ci-complete:
+    runs-on: ubuntu-20.04
+    needs: [ci, ci-buildifier]
+    steps:
+      - name: Mark CI as successful
+        run: echo Done


### PR DESCRIPTION
Instead of trying to check that all builds are green, the new `ci-complete` build can be used to determine whether or not all of CI was successful or not.