### PR TITLE
CI should show error logs

### DIFF
--- a/.github/github.bazelrc
+++ b/.github/github.bazelrc
@@ -10,6 +10,9 @@ build --enable_runfiles
 # Enable all strict flags
 build --config=strict
 
+# Show errors in CI
+test --test_output=errors
+
 # UI for cleaner CI output
 common --color=no
 common --curses=no


### PR DESCRIPTION
simply enable [--test_output](https://docs.bazel.build/versions/main/command-line-reference.html#flag--test_output)