### PR TITLE
Filter any existing Cargo config files for consistent rendering

### DIFF
--- a/private/splicing_utils.bzl
+++ b/private/splicing_utils.bzl
@@ -91,6 +91,11 @@ def splice_workspace_manifest(repository_ctx, generator, lockfile, cargo, rustc)
 
     manifests = {str(repository_ctx.path(m)): str(m) for m in repository_ctx.attr.manifests}
 
+    if repository_ctx.attr.cargo_config:
+        cargo_config = str(repository_ctx.path(repository_ctx.attr.cargo_config))
+    else:
+        cargo_config = None
+
     # Serialize information required for splicing
     splicing_manifest = repository_ctx.path("{}/splicing_manifest.json".format(repo_dir))
     repository_ctx.file(
@@ -99,6 +104,7 @@ def splice_workspace_manifest(repository_ctx, generator, lockfile, cargo, rustc)
             direct_packages = direct_packages_info,
             extra_manifest_infos = extra_manifest_info,
             manifests = manifests,
+            cargo_config = cargo_config,
         ), indent = " " * 4),
     )
 

--- a/tools/cargo_bazel/src/splicing.rs
+++ b/tools/cargo_bazel/src/splicing.rs
@@ -46,6 +46,9 @@ pub struct SplicingManifest {
 
     /// A mapping of manifest paths to the labels representing them
     pub manifests: BTreeMap<PathBuf, Label>,
+
+    /// The path of a Cargo config file
+    pub cargo_config: Option<PathBuf>,
 }
 
 impl FromStr for SplicingManifest {
@@ -202,11 +205,14 @@ impl WorkspaceMetadata {
 
         // Load the cargo config
         let cargo_config = {
+            // Note that this path must match the one defined in `splicing::setup_cargo_config`
             let config_path = manifest_path
                 .as_path_buf()
                 .parent()
                 .unwrap()
+                .join(".cargo")
                 .join("config.toml");
+
             if config_path.exists() {
                 Some(CargoConfig::from_path(&config_path)?)
             } else {


### PR DESCRIPTION
Now more than `config.toml` at the root of the repo is supported. Additionally, unspecified configs will go ignored.