### PR TITLE
Handle cases where build dependencies are also normal dependencies

### DIFF
--- a/tools/cargo_bazel/src/annotation/dependency.rs
+++ b/tools/cargo_bazel/src/annotation/dependency.rs
@@ -37,7 +37,7 @@ impl DependencySet {
                 // Do not track workspace members as dependencies. Users are expected to maintain those connections
                 .filter(|dep| !is_workspace_member(dep, metadata))
                 .filter(|dep| is_lib_package(&metadata[&dep.pkg]))
-                .filter(|dep| !is_build_dependency(dep))
+                .filter(|dep| is_normal_dependency(dep) || is_dev_dependency(dep))
                 .partition(|dep| is_dev_dependency(dep));
 
             (
@@ -168,6 +168,13 @@ fn is_build_dependency(node_dep: &NodeDep) -> bool {
         .dep_kinds
         .iter()
         .any(|k| matches!(k.kind, cargo_metadata::DependencyKind::Build))
+}
+
+fn is_normal_dependency(node_dep: &NodeDep) -> bool {
+    node_dep
+        .dep_kinds
+        .iter()
+        .any(|k| matches!(k.kind, cargo_metadata::DependencyKind::Normal))
 }
 
 fn is_workspace_member(node_dep: &NodeDep, metadata: &CargoMetadata) -> bool {


### PR DESCRIPTION
This is something that would definitely benefit from unit testing. The `cargo-metadata` crate translates `"kind": null` to Normal dependencies ([see source code](https://github.com/oli-obk/cargo_metadata/blob/v0.14.0/src/dependency.rs#L42-L48)). This seems correct but also feels like it's something that's subject to change in a subtle way to be more explicit and I'm nervous that could introduce an incompatibility.