### PR TITLE
Binary targets should always depend on the package library target

### DIFF
--- a/tools/cargo_bazel/src/rendering/templates/partials/crate/binary.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/crate/binary.j2
@@ -1,6 +1,9 @@
 rust_binary(
     name = "{{ target.crate_name }}__bin",
     deps = [
+        {%- if crate.library_target_name %}
+        ":{{ crate.library_target_name }}",
+        {%- endif %}
         {%- for dep in crate.common_attrs | get(key="extra_deps", default=[]) %}
         "{{ dep }}",
         {%- endfor %}


### PR DESCRIPTION
This may not be correct in every case but to my knowledge library targets are always available to binary targets so it's not easy to otherwise determine when the dependency is or is not needed.