### PR TITLE
Updated Cargo build script target names to conform to Bazel rule

### DIFF
--- a/tools/cargo_bazel/src/rendering/templates/partials/crate/build_script.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/crate/build_script.j2
@@ -1,5 +1,15 @@
-cargo_build_script(
+alias(
+    # Because `cargo_build_script` does some invisible target name mutating to
+    # determine the package and crate name for a build script, the Bazel
+    # target namename of any build script cannot be the Cargo canonical name
+    # of `build_script_build` without losing out on having certain Cargo
+    # environment variables set.
     name = "{{ target.crate_name }}",
+    actual = "{{ crate.name }}_build_script",
+)
+cargo_build_script(
+    # See comment associated with alias. Do not change this name
+    name = "{{ crate.name }}_build_script",
     aliases = {% set selectable = build_aliases %}{% include "partials/crate/aliases.j2" -%},
     build_script_env = {% set selectable = crate.build_script_attrs | get(key="build_script_env", default=Null) %}{% include "partials/starlark/selectable_dict.j2" -%},
     compile_data = {% if crate.build_script_attrs | get(key="compile_data_glob") %}glob({{ crate.build_script_attrs.compile_data_glob | json_encode | safe }}) + {% endif %}{% set selectable = crate.build_script_attrs | get(key="compile_data", default=Null) %}{% include "partials/starlark/selectable_list.j2" %},


### PR DESCRIPTION
[`@rules_rust//cargo:cargo_build_script.bzl%cargo_build_script`](https://github.com/bazelbuild/rules_rust/blob/82b650d5d0709ae4c0ee8584f4ed92112ba11d67/cargo/cargo_build_script.bzl#L245-L329) has (in some cases, like [ring](https://github.com/briansmith/ring/blob/9cc0d45f4d8521f467bb3a621e74b1535e118188/build.rs#L238)) [a requirement](https://github.com/bazelbuild/rules_rust/blob/82b650d5d0709ae4c0ee8584f4ed92112ba11d67/cargo/cargo_build_script.bzl#L367-L370) that the target name is `{crate package name}_build_script` in order to correctly set the [`CARGO_PKG_NAME` and `CARGO_CRATE_NAME` variables](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) instead of the canonical `build_script_build` target name that Cargo uses. This change updates the name of the target and provides an alias to maintain accurate target name mappings as best as possible.