### PR TITLE
Fix errors for missing crates due to them being both normal and dev deps

### DIFF
--- a/tools/cargo_bazel/src/annotation/dependency.rs
+++ b/tools/cargo_bazel/src/annotation/dependency.rs
@@ -157,10 +157,15 @@ fn is_proc_macro_package(package: &Package) -> bool {
 }
 
 fn is_dev_dependency(node_dep: &NodeDep) -> bool {
-    node_dep
+    let is_normal_dep = is_normal_dependency(node_dep);
+    let is_dev_dep = node_dep
         .dep_kinds
         .iter()
-        .any(|k| matches!(k.kind, cargo_metadata::DependencyKind::Development))
+        .any(|k| matches!(k.kind, cargo_metadata::DependencyKind::Development));
+
+    // In the event that a dependency is listed as both a dev and normal dependency,
+    // it's only considered a dev dependency if it's __not__ a normal dependency.
+    !is_normal_dep && is_dev_dep
 }
 
 fn is_build_dependency(node_dep: &NodeDep) -> bool {


### PR DESCRIPTION
While seemingly odd (to me), there are valid cases where the same crate is defined in both `[dependencies]` and `[dev-dependencies]`. This change accounts for that scenario and allows crates to accurately be mapped in the generated `crates_repository` macros.