### PR TITLE
Updated `tera` dependency to account for yanked versions

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "bb57f9bcc09ac65ea9b08316d0079ba5c2bfddc2951f0b07a5d870dc4fa9cf8c",
+  "checksum": "9359ff2a0eab390c256baa39abc736bcb0071628ec8e80ff79ada93fbb70fc58",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -85,13 +85,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.44": {
+    "anyhow 1.0.45": {
       "name": "anyhow",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.44/download",
-          "sha256": "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.45/download",
+          "sha256": "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
         }
       },
       "targets": [
@@ -129,14 +129,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.44",
+              "id": "anyhow 1.0.45",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.44"
+        "version": "1.0.45"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -583,7 +583,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.44",
+              "id": "anyhow 1.0.45",
               "target": "anyhow"
             },
             {
@@ -5163,9 +5163,12 @@
       "name": "tera",
       "version": "1.14.0",
       "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/tera/1.14.0/download",
-          "sha256": "3e7f3fd1bd7e48ef73d9e9124caedee3e1c645657ec876a50a278c8d0555d9da"
+        "Git": {
+          "remote": "https://github.com/Keats/tera.git",
+          "commitish": {
+            "Rev": "a6bcf2d358cd41ec9245e9287f3d216007c23239"
+          },
+          "shallow_since": "1635772231 +0100"
         }
       },
       "targets": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "atty"
@@ -1007,8 +1007,7 @@ dependencies = [
 [[package]]
 name = "tera"
 version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7f3fd1bd7e48ef73d9e9124caedee3e1c645657ec876a50a278c8d0555d9da"
+source = "git+https://github.com/Keats/tera.git?rev=a6bcf2d358cd41ec9245e9287f3d216007c23239#a6bcf2d358cd41ec9245e9287f3d216007c23239"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -48,6 +48,7 @@ crates_repository(
         )],
         "tera": [crate.extras(
             compile_data_glob = ["**/*.pest"],
+            shallow_since = "1635772231 +0100",
         )],
         "unic-ucd-segment": [crate.extras(
             compile_data_glob = ["**/*.rsv"],

--- a/tools/cargo_bazel/Cargo.toml
+++ b/tools/cargo_bazel/Cargo.toml
@@ -24,7 +24,8 @@ serde = "1.0.130"
 serde_json = "1.0.68"
 sha2 = "0.9.8"
 structopt = "0.3.25"
-tera = "1.14.0"
+# https://github.com/Keats/tera/issues/689
+tera = { git = "https://github.com/Keats/tera.git", rev = "a6bcf2d358cd41ec9245e9287f3d216007c23239" }
 textwrap = "0.14.2"
 toml = "0.5.8"
 


### PR DESCRIPTION
There seems to be issues related to recent releases. However, since the code is currently using https://github.com/Keats/tera/pull/671 it's better to just grab a compatible version via `git` for now and wait for a new release.