### PR TITLE
Release `v0.0.9`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "9359ff2a0eab390c256baa39abc736bcb0071628ec8e80ff79ada93fbb70fc58",
+  "checksum": "75318dc57e1ad39a6cc7ded7027e455bac3794de0547f84953788016804f9f37",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -548,9 +548,9 @@
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
     },
-    "cargo-bazel 0.0.8": {
+    "cargo-bazel 0.0.9": {
       "name": "cargo-bazel",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "repository": null,
       "targets": [
         {
@@ -643,7 +643,7 @@
               "target": "structopt"
             },
             {
-              "id": "tera 1.14.0",
+              "id": "tera 1.15.0",
               "target": "tera"
             },
             {
@@ -667,7 +667,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.0.8"
+        "version": "0.0.9"
       },
       "license": null
     },
@@ -5159,16 +5159,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "tera 1.14.0": {
+    "tera 1.15.0": {
       "name": "tera",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "repository": {
-        "Git": {
-          "remote": "https://github.com/Keats/tera.git",
-          "commitish": {
-            "Rev": "a6bcf2d358cd41ec9245e9287f3d216007c23239"
-          },
-          "shallow_since": "1635772231 +0100"
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/tera/1.15.0/download",
+          "sha256": "d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d"
         }
       },
       "targets": [
@@ -5267,7 +5264,7 @@
           ],
           "selects": {}
         },
-        "version": "1.14.0"
+        "version": "1.15.0"
       },
       "license": "MIT"
     },
@@ -6645,7 +6642,7 @@
     "phf_generator 0.10.0"
   ],
   "workspace_members": {
-    "cargo-bazel 0.0.8": "tools/cargo_bazel",
+    "cargo-bazel 0.0.9": "tools/cargo_bazel",
     "cross_installer 0.1.0": "tools/cross_installer",
     "direct-cargo-bazel-deps 0.0.1": "",
     "urls_generator 0.1.0": "tools/urls_generator"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-bazel"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -1006,8 +1006,9 @@ dependencies = [
 
 [[package]]
 name = "tera"
-version = "1.14.0"
-source = "git+https://github.com/Keats/tera.git?rev=a6bcf2d358cd41ec9245e9287f3d216007c23239#a6bcf2d358cd41ec9245e9287f3d216007c23239"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3cac831b615c25bcef632d1cabf864fa05813baad3d526829db18eb70e8b58d"
 dependencies = [
  "chrono",
  "chrono-tz",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -48,7 +48,6 @@ crates_repository(
         )],
         "tera": [crate.extras(
             compile_data_glob = ["**/*.pest"],
-            shallow_since = "1635772231 +0100",
         )],
         "unic-ucd-segment": [crate.extras(
             compile_data_glob = ["**/*.rsv"],

--- a/examples/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "2e2751db11bcaecd6315beea87550a1dd9514564adcea28ac5bf50813421b511",
+  "checksum": "261b583e3ec8e65739d0cb96a0cf66868e52311684eed688036adc4dd01e25fc",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -132,7 +132,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -315,7 +315,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -356,13 +356,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.105": {
+    "libc 0.2.106": {
       "name": "libc",
-      "version": "0.2.105",
+      "version": "0.2.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.105/download",
-          "sha256": "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.106/download",
+          "sha256": "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
         }
       },
       "targets": [
@@ -396,14 +396,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.105"
+        "version": "0.2.106"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"

--- a/examples/cargo_workspace/Cargo.Bazel.lock
+++ b/examples/cargo_workspace/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "7394ac4f26759e220fcc3f1d37b2f4481d40c5ea78e51c9ab17a8c248d7cd606",
+  "checksum": "12fb3e18d7f60117cc32820a804f2cc597bbb9f3be09e1a07b065d1aad2e1bcb",
   "crates": {
     "ansi_term 0.11.0": {
       "name": "ansi_term",
@@ -78,7 +78,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -365,7 +365,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ]
@@ -408,7 +408,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -419,13 +419,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.105": {
+    "libc 0.2.106": {
       "name": "libc",
-      "version": "0.2.105",
+      "version": "0.2.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.105/download",
-          "sha256": "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.106/download",
+          "sha256": "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
         }
       },
       "targets": [
@@ -459,14 +459,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.105"
+        "version": "0.2.106"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -633,7 +633,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ]

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ff5c9285f540db9b14e15057b91ed59a1d55d6fdd585c8378a54ec16e9c66512",
+  "checksum": "837c8d0a1f4235d4202856ace63f0f684a0ad9f86f682f4de556fe81d625f46a",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -112,7 +112,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -425,7 +425,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -816,7 +816,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -1017,13 +1017,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.105": {
+    "libc 0.2.106": {
       "name": "libc",
-      "version": "0.2.105",
+      "version": "0.2.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.105/download",
-          "sha256": "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.106/download",
+          "sha256": "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
         }
       },
       "targets": [
@@ -1061,14 +1061,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.105"
+        "version": "0.2.106"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -1421,7 +1421,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -2390,7 +2390,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "17ba0790370d385a57c47e277023d131f367081d3d62f79747b37d8f35ac19e1",
+  "checksum": "19bd98a75fb84c66e79d15918b9424a2999a684ec5d516a8efcbcefe20db6d1c",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -44,13 +44,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "anyhow 1.0.44": {
+    "anyhow 1.0.45": {
       "name": "anyhow",
-      "version": "1.0.44",
+      "version": "1.0.45",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.44/download",
-          "sha256": "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.45/download",
+          "sha256": "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
         }
       },
       "targets": [
@@ -88,14 +88,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.44",
+              "id": "anyhow 1.0.45",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.44"
+        "version": "1.0.45"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -426,7 +426,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -611,7 +611,7 @@
                 "target": "async_io"
               },
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               },
               {
@@ -946,7 +946,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -1570,7 +1570,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -1797,13 +1797,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "curl 0.4.39": {
+    "curl 0.4.40": {
       "name": "curl",
-      "version": "0.4.39",
+      "version": "0.4.40",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/curl/0.4.39/download",
-          "sha256": "aaa3b8db7f3341ddef15786d250106334d4a6c4b0ae4a46cd77082777d9849b9"
+          "url": "https://crates.io/api/v1/crates/curl/0.4.40/download",
+          "sha256": "877cc2f9b8367e32b6dabb9d581557e651cb3aa693a37f8679091bbf42687d5d"
         }
       },
       "targets": [
@@ -1845,15 +1845,15 @@
         "deps": {
           "common": [
             {
-              "id": "curl 0.4.39",
+              "id": "curl 0.4.40",
               "target": "build_script_build"
             },
             {
-              "id": "curl-sys 0.4.49+curl-7.79.1",
+              "id": "curl-sys 0.4.50+curl-7.79.1",
               "target": "curl_sys"
             },
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -1868,7 +1868,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.68",
+                "id": "openssl-sys 0.9.70",
                 "target": "openssl_sys"
               }
             ],
@@ -1885,13 +1885,13 @@
           }
         },
         "edition": "2018",
-        "version": "0.4.39"
+        "version": "0.4.40"
       },
       "build_script_attrs": {
         "deps": {
           "common": [
             {
-              "id": "curl-sys 0.4.49+curl-7.79.1",
+              "id": "curl-sys 0.4.50+curl-7.79.1",
               "target": "curl_sys"
             }
           ],
@@ -1900,13 +1900,13 @@
       },
       "license": "MIT"
     },
-    "curl-sys 0.4.49+curl-7.79.1": {
+    "curl-sys 0.4.50+curl-7.79.1": {
       "name": "curl-sys",
-      "version": "0.4.49+curl-7.79.1",
+      "version": "0.4.50+curl-7.79.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/curl-sys/0.4.49+curl-7.79.1/download",
-          "sha256": "e0f44960aea24a786a46907b8824ebc0e66ca06bf4e4978408c7499620343483"
+          "url": "https://crates.io/api/v1/crates/curl-sys/0.4.50+curl-7.79.1/download",
+          "sha256": "4856b76919dd599f31236bb18db5f5bd36e2ce131e64f857ca5c259665b76171"
         }
       },
       "targets": [
@@ -1936,7 +1936,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -1951,7 +1951,7 @@
           "selects": {
             "cfg(all(unix, not(target_os = \"macos\")))": [
               {
-                "id": "openssl-sys 0.9.68",
+                "id": "openssl-sys 0.9.70",
                 "target": "openssl_sys"
               }
             ],
@@ -1968,7 +1968,7 @@
           "@libssh2"
         ],
         "edition": "2018",
-        "version": "0.4.49+curl-7.79.1"
+        "version": "0.4.50+curl-7.79.1"
       },
       "license": "MIT"
     },
@@ -2194,7 +2194,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -3217,7 +3217,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ]
@@ -3349,11 +3349,11 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.8",
+              "id": "tokio-util 0.6.9",
               "target": "tokio_util"
             },
             {
@@ -3432,7 +3432,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -3765,7 +3765,7 @@
               "target": "serde_regex"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             }
           ],
@@ -3872,7 +3872,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
@@ -3935,7 +3935,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
@@ -4195,11 +4195,11 @@
               "target": "crossbeam_utils"
             },
             {
-              "id": "curl 0.4.39",
+              "id": "curl 0.4.40",
               "target": "curl"
             },
             {
-              "id": "curl-sys 0.4.49+curl-7.79.1",
+              "id": "curl-sys 0.4.50+curl-7.79.1",
               "target": "curl_sys"
             },
             {
@@ -4646,13 +4646,13 @@
       },
       "license": "MIT"
     },
-    "libc 0.2.105": {
+    "libc 0.2.106": {
       "name": "libc",
-      "version": "0.2.105",
+      "version": "0.2.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.105/download",
-          "sha256": "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.106/download",
+          "sha256": "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
         }
       },
       "targets": [
@@ -4690,14 +4690,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.105"
+        "version": "0.2.106"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -4745,7 +4745,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -4818,7 +4818,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -5174,7 +5174,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -5289,7 +5289,7 @@
                 "target": "lazy_static"
               },
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               },
               {
@@ -5311,7 +5311,7 @@
                 "target": "log"
               },
               {
-                "id": "openssl 0.10.37",
+                "id": "openssl 0.10.38",
                 "target": "openssl"
               },
               {
@@ -5319,7 +5319,7 @@
                 "target": "openssl_probe"
               },
               {
-                "id": "openssl-sys 0.9.68",
+                "id": "openssl-sys 0.9.70",
                 "target": "openssl_sys"
               }
             ],
@@ -5455,7 +5455,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -5539,13 +5539,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "openssl 0.10.37": {
+    "openssl 0.10.38": {
       "name": "openssl",
-      "version": "0.10.37",
+      "version": "0.10.38",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl/0.10.37/download",
-          "sha256": "2bc6b9e4403633698352880b22cbe2f0e45dd0177f6fabe4585536e56a3e4f75"
+          "url": "https://crates.io/api/v1/crates/openssl/0.10.38/download",
+          "sha256": "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
         }
       },
       "targets": [
@@ -5591,7 +5591,7 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -5599,11 +5599,11 @@
               "target": "once_cell"
             },
             {
-              "id": "openssl 0.10.37",
+              "id": "openssl 0.10.38",
               "target": "build_script_build"
             },
             {
-              "id": "openssl-sys 0.9.68",
+              "id": "openssl-sys 0.9.70",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -5611,13 +5611,13 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.37"
+        "version": "0.10.38"
       },
       "build_script_attrs": {
         "deps": {
           "common": [
             {
-              "id": "openssl-sys 0.9.68",
+              "id": "openssl-sys 0.9.70",
               "target": "openssl_sys",
               "alias": "ffi"
             }
@@ -5657,13 +5657,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "openssl-sys 0.9.68": {
+    "openssl-sys 0.9.70": {
       "name": "openssl-sys",
-      "version": "0.9.68",
+      "version": "0.9.70",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.68/download",
-          "sha256": "1c571f25d3f66dd427e417cebf73dbe2361d6125cf6e3a70d143fdf97c9f5150"
+          "url": "https://crates.io/api/v1/crates/openssl-sys/0.9.70/download",
+          "sha256": "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
         }
       },
       "targets": [
@@ -5703,11 +5703,11 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
-              "id": "openssl-sys 0.9.68",
+              "id": "openssl-sys 0.9.70",
               "target": "build_script_main"
             }
           ],
@@ -5717,7 +5717,7 @@
           "@openssl"
         ],
         "edition": "2015",
-        "version": "0.9.68"
+        "version": "0.9.70"
       },
       "build_script_attrs": {
         "data": {
@@ -5910,7 +5910,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -6273,7 +6273,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.44",
+              "id": "anyhow 1.0.45",
               "target": "anyhow"
             },
             {
@@ -6320,7 +6320,7 @@
         "deps": {
           "common": [
             {
-              "id": "openssl 0.10.37",
+              "id": "openssl 0.10.38",
               "target": "openssl"
             }
           ],
@@ -6417,7 +6417,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -6805,7 +6805,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ]
@@ -7298,7 +7298,7 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.12.0",
+                "id": "tokio 1.13.0",
                 "target": "tokio"
               },
               {
@@ -7558,7 +7558,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -7609,7 +7609,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -7960,7 +7960,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -8008,7 +8008,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -8197,7 +8197,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -8395,7 +8395,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -8606,13 +8606,13 @@
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.12.0": {
+    "tokio 1.13.0": {
       "name": "tokio",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.12.0/download",
-          "sha256": "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+          "url": "https://crates.io/api/v1/crates/tokio/1.13.0/download",
+          "sha256": "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
         }
       },
       "targets": [
@@ -8690,14 +8690,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               },
               {
@@ -8717,13 +8717,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tokio-macros 1.5.0",
+              "id": "tokio-macros 1.5.1",
               "target": "tokio_macros"
             }
           ],
           "selects": {}
         },
-        "version": "1.12.0"
+        "version": "1.13.0"
       },
       "build_script_attrs": {
         "deps": {
@@ -8738,13 +8738,13 @@
       },
       "license": "MIT"
     },
-    "tokio-macros 1.5.0": {
+    "tokio-macros 1.5.1": {
       "name": "tokio-macros",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-macros/1.5.0/download",
-          "sha256": "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+          "url": "https://crates.io/api/v1/crates/tokio-macros/1.5.1/download",
+          "sha256": "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
         }
       },
       "targets": [
@@ -8781,7 +8781,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.5.0"
+        "version": "1.5.1"
       },
       "license": "MIT"
     },
@@ -8817,7 +8817,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             }
           ],
@@ -8828,13 +8828,13 @@
       },
       "license": "MIT"
     },
-    "tokio-util 0.6.8": {
+    "tokio-util 0.6.9": {
       "name": "tokio-util",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.8/download",
-          "sha256": "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.9/download",
+          "sha256": "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
         }
       },
       "targets": [
@@ -8880,14 +8880,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.8"
+        "version": "0.6.9"
       },
       "license": "MIT"
     },

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8e89e87797ec2f808d422182446421a23ab1834fa5cc6ff1135532c66fbe41ea",
+  "checksum": "0992eccc7069fa87f56c1c863320f51897a0590dc3e6b5d078368f495770d73a",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -259,11 +259,11 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.8",
+              "id": "tokio-util 0.6.9",
               "target": "tokio_util"
             },
             {
@@ -430,7 +430,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             },
             {
@@ -491,7 +491,7 @@
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
@@ -944,11 +944,11 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.8",
+              "id": "tokio-util 0.6.9",
               "target": "tokio_util"
             },
             {
@@ -1027,7 +1027,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -1307,7 +1307,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
@@ -1502,13 +1502,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.105": {
+    "libc 0.2.106": {
       "name": "libc",
-      "version": "0.2.105",
+      "version": "0.2.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.105/download",
-          "sha256": "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.106/download",
+          "sha256": "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
         }
       },
       "targets": [
@@ -1546,14 +1546,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.105"
+        "version": "0.2.106"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -1826,7 +1826,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -2106,7 +2106,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -2275,7 +2275,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -3086,7 +3086,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.105",
+              "id": "libc 0.2.106",
               "target": "libc"
             }
           ],
@@ -3191,7 +3191,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               }
             ],
@@ -3354,13 +3354,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "tokio 1.12.0": {
+    "tokio 1.13.0": {
       "name": "tokio",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.12.0/download",
-          "sha256": "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+          "url": "https://crates.io/api/v1/crates/tokio/1.13.0/download",
+          "sha256": "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
         }
       },
       "targets": [
@@ -3447,14 +3447,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.105",
+                "id": "libc 0.2.106",
                 "target": "libc"
               },
               {
@@ -3474,13 +3474,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tokio-macros 1.5.0",
+              "id": "tokio-macros 1.5.1",
               "target": "tokio_macros"
             }
           ],
           "selects": {}
         },
-        "version": "1.12.0"
+        "version": "1.13.0"
       },
       "build_script_attrs": {
         "deps": {
@@ -3495,13 +3495,13 @@
       },
       "license": "MIT"
     },
-    "tokio-macros 1.5.0": {
+    "tokio-macros 1.5.1": {
       "name": "tokio-macros",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-macros/1.5.0/download",
-          "sha256": "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+          "url": "https://crates.io/api/v1/crates/tokio-macros/1.5.1/download",
+          "sha256": "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
         }
       },
       "targets": [
@@ -3538,17 +3538,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.5.0"
+        "version": "1.5.1"
       },
       "license": "MIT"
     },
-    "tokio-util 0.6.8": {
+    "tokio-util 0.6.9": {
       "name": "tokio-util",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.8/download",
-          "sha256": "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+          "url": "https://crates.io/api/v1/crates/tokio-util/0.6.9/download",
+          "sha256": "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
         }
       },
       "targets": [
@@ -3594,14 +3594,14 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.6.8"
+        "version": "0.6.9"
       },
       "license": "MIT"
     },
@@ -3660,11 +3660,11 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.12.0",
+              "id": "tokio 1.13.0",
               "target": "tokio"
             },
             {
-              "id": "tokio-util 0.6.8",
+              "id": "tokio-util 0.6.9",
               "target": "tokio_util"
             },
             {

--- a/tools/cargo_bazel/Cargo.toml
+++ b/tools/cargo_bazel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bazel"
-version = "0.0.8"
+version = "0.0.9"
 authors = [
     "UebelAndre - github@uebelandre.com",
 ]
@@ -24,8 +24,7 @@ serde = "1.0.130"
 serde_json = "1.0.68"
 sha2 = "0.9.8"
 structopt = "0.3.25"
-# https://github.com/Keats/tera/issues/689
-tera = { git = "https://github.com/Keats/tera.git", rev = "a6bcf2d358cd41ec9245e9287f3d216007c23239" }
+tera = "1.15.0"
 textwrap = "0.14.2"
 toml = "0.5.8"
 

--- a/tools/cargo_bazel/src/rendering/template_engine.rs
+++ b/tools/cargo_bazel/src/rendering/template_engine.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context as AnyhowContext, Result};
 use serde_json::{from_value, to_value, Value};
-use tera::{self, CtxThreadSafe, Tera};
+use tera::{self, Tera};
 
 use crate::config::{CrateId, RenderConfig};
 use crate::context::Context;
@@ -18,7 +18,7 @@ use crate::utils::starlark::{SelectStringDict, SelectStringList};
 
 pub struct TemplateEngine {
     engine: Tera,
-    context: tera::Context<CtxThreadSafe>,
+    context: tera::Context,
 }
 
 impl TemplateEngine {
@@ -196,7 +196,7 @@ impl TemplateEngine {
         }
     }
 
-    fn new_tera_ctx(&self) -> tera::Context<CtxThreadSafe> {
+    fn new_tera_ctx(&self) -> tera::Context {
         self.context.clone()
     }
 

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """ Version info for the `cargo-bazel` repository """
 
-VERSION = "0.0.8"
+VERSION = "0.0.9"


### PR DESCRIPTION
This release should wait for a legitimate release of `tera` and not rely on the git repository.