### PR TITLE
Fixed Cargo config files being ignored

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -142,11 +142,11 @@ Environment Variables:
         ),
         "isolated": attr.bool(
             doc = (
-                "If true, `CARGO_HOME` will be set to a directory within the generated repository to prevent " +
-                "other uses of Cargo from impacting having any effect on the generated targets produced by " +
-                "this rule."
+                "If true, `CARGO_HOME` will be overwritten to a directory within the generated repository in " +
+                "order to prevent other uses of Cargo from impacting having any effect on the generated targets " +
+                "produced by this rule."
             ),
-            default = False,
+            default = True,
         ),
         "lockfile": attr.label(
             doc = (

--- a/private/common_utils.bzl
+++ b/private/common_utils.bzl
@@ -53,6 +53,17 @@ def get_rust_tools(repository_ctx, host_triple):
     Returns:
         struct: A struct containing the expected rust tools
     """
+
+    # This is a bit hidden but to ensure Cargo behaves consistently based
+    # on the user provided config file, the config file is installed into
+    # the `CARGO_HOME` path. This is done so here since fetching tools
+    # is expected to always occur before any subcommands are run.
+    if repository_ctx.attr.isolated and repository_ctx.attr.cargo_config:
+        cargo_home = cargo_home_path(repository_ctx)
+        cargo_home_config = repository_ctx.path("{}/config.toml".format(cargo_home))
+        cargo_config = repository_ctx.path(repository_ctx.attr.cargo_config)
+        repository_ctx.symlink(cargo_config, cargo_home_config)
+
     return _rust_get_rust_tools(
         repository_ctx = repository_ctx,
         toolchain_repository_template = repository_ctx.attr.rust_toolchain_repo_template,

--- a/tools/cargo_bazel/src/cli/splice.rs
+++ b/tools/cargo_bazel/src/cli/splice.rs
@@ -57,16 +57,6 @@ pub fn splice(opt: SpliceOptions) -> Result<()> {
     // Splice together the manifest
     let manifest_path = splicer.splice_workspace()?;
 
-    // Ensure the cargo config is installed for generating metadata and lock data
-    if let Some(cargo_config) = &opt.cargo_config {
-        let target_path = manifest_path
-            .as_path_buf()
-            .parent()
-            .unwrap()
-            .join("config.toml");
-        crate::splicing::install_file(cargo_config, &target_path)?;
-    }
-
     // Generate a lockfile
     let cargo_lockfile =
         generate_lockfile(&manifest_path, &opt.cargo_lockfile, &opt.cargo, &opt.rustc)?;

--- a/tools/cargo_bazel/src/metadata.rs
+++ b/tools/cargo_bazel/src/metadata.rs
@@ -100,6 +100,10 @@ impl LockGenerator {
             // Ensure the Cargo cache is up to date to simulate the behavior
             // of having just generated a new one
             Command::new(&self.cargo_bin)
+                // Cargo detects config files based on `pwd` when running so
+                // to ensure user provided Cargo config files are used, it's
+                // critical to set the working directory to the manifest dir.
+                .current_dir(manifest_dir)
                 .arg("fetch")
                 .arg("--locked")
                 .arg("--manifest-path")
@@ -113,6 +117,10 @@ impl LockGenerator {
         } else {
             // Simply invoke `cargo generate-lockfile`
             Command::new(&self.cargo_bin)
+                // Cargo detects config files based on `pwd` when running so
+                // to ensure user provided Cargo config files are used, it's
+                // critical to set the working directory to the manifest dir.
+                .current_dir(manifest_dir)
                 .arg("generate-lockfile")
                 .arg("--manifest-path")
                 .arg(manifest_path)

--- a/tools/cargo_bazel/src/splicing.rs
+++ b/tools/cargo_bazel/src/splicing.rs
@@ -335,14 +335,6 @@ impl SplicedManifest {
     }
 }
 
-// Copies a file into place ensuring no symlink was present in it's place
-pub fn install_file(src: &Path, dest: &Path) -> Result<()> {
-    fs::remove_file(dest)?;
-    fs::copy(src, dest)?;
-
-    Ok(())
-}
-
 pub fn read_manifest(manifest: &Path) -> Result<Manifest> {
     let content = fs::read_to_string(manifest)?;
     cargo_toml::Manifest::from_str(content.as_str()).context("Failed to deserialize manifest")


### PR DESCRIPTION
It turns out [Cargo configuration files](https://doc.rust-lang.org/cargo/reference/config.html) are only detected based on the current working directory where Cargo is being executed. The failed assumption here was that [--manifest-path](https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options) would instead be used as it seems to be the more relevant directory. If I `cargo build` in one workspace but pass `--manifest-path` to another, Cargo should correctly look for config files based on the manifest being built.