### PR TITLE
Enabled rustdoc targets

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -8,11 +8,11 @@ def cargo_bazel_deps():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "59ffb4b9d26525e1ed2cfb45eb0253bbf3b1d8974cda58f93a14183c47d28b3c",
-        strip_prefix = "rules_rust-332542944e0c444e689ab011955df462f8f1f2b5",
+        sha256 = "69934a7953e5267ac18b751d6b109bc9e906d4a5d887f68cdd1940f172b64254",
+        strip_prefix = "rules_rust-e7b1e5ab9afcccc8d301c2b8922cae815d20c714",
         urls = [
-            # `main` branch as of 2021-11-08
-            "https://github.com/bazelbuild/rules_rust/archive/332542944e0c444e689ab011955df462f8f1f2b5.tar.gz",
+            # `main` branch as of 2021-11-15
+            "https://github.com/bazelbuild/rules_rust/archive/e7b1e5ab9afcccc8d301c2b8922cae815d20c714.tar.gz",
         ],
     )
 

--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -93,3 +93,8 @@ sh_binary(
         ":mdbook",
     ],
 )
+
+alias(
+    name = "cargo_bazel_rustdoc",
+    actual = "//tools/cargo_bazel:rustdoc",
+)

--- a/tools/cargo_bazel/BUILD.bazel
+++ b/tools/cargo_bazel/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_doc", "rust_library", "rust_test")
 load("//:version.bzl", "VERSION")
 
 package(default_visibility = ["//visibility:public"])
@@ -60,8 +60,7 @@ rust_test(
     ),
 )
 
-# TODO: https://github.com/bazelbuild/rules_rust/issues/947
-# rust_doc(
-#     name = "rustdoc",
-#     crate = ":cargo_bazel",
-# )
+rust_doc(
+    name = "rustdoc",
+    crate = ":cargo_bazel",
+)


### PR DESCRIPTION
Now that [rustdoc](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html) targets are being built, they should be hosted in the docs site. But that's a change for another day.