### PR TITLE
Added support for wildcard `crate.extras`

### DIFF
--- a/tools/cargo_bazel/src/annotation/dependency.rs
+++ b/tools/cargo_bazel/src/annotation/dependency.rs
@@ -17,7 +17,7 @@ pub struct Dependency {
     pub alias: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct DependencySet {
     pub normal_deps: SelectList<Dependency>,
     pub normal_dev_deps: SelectList<Dependency>,

--- a/tools/cargo_bazel/src/context/crate_context.rs
+++ b/tools/cargo_bazel/src/context/crate_context.rs
@@ -1,4 +1,4 @@
-//! TODO
+//! Crate specific information embedded into [crate::context::Context] objects.
 
 use std::collections::{BTreeMap, BTreeSet};
 


### PR DESCRIPTION
This adds support for adding wildcard `*` `crate.extras` definitions for setting extra flags on targets generated by `cargo-bazel`:

```python
crates_repository(
    name = "crate_index",
    extras = {
        "*": [crate.extras(
            build_script_data_glob = ["**"]
        )],
    },
    lockfile = "//:Cargo.Bazel.lock",
    manifests = ["//:Cargo.toml"],
)
```

The snippet above adds the `"**"` pattern to every `cargo_build_script` target. This specific case can be quite handy because it can be quite tedious to set each individual glob pattern for every crate that has a build script. Using the `extras` snippet above allows build scripts to have access to all files in the crate (though, for some larger crates this may be a performance hit).
