### PR TITLE
Allow explicitly setting both Cargo and Rustc labels

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -115,13 +115,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.48": {
+    "anyhow 1.0.51": {
       "name": "anyhow",
-      "version": "1.0.48",
+      "version": "1.0.51",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.48/download",
-          "sha256": "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.51/download",
+          "sha256": "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
         }
       },
       "targets": [
@@ -159,14 +159,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.48",
+              "id": "anyhow 1.0.51",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.48"
+        "version": "1.0.51"
       },
       "build_script_attrs": {},
       "license": "MIT OR Apache-2.0"
@@ -613,7 +613,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.48",
+              "id": "anyhow 1.0.51",
               "target": "anyhow"
             },
             {
@@ -4521,13 +4521,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "ryu 1.0.5": {
+    "ryu 1.0.6": {
       "name": "ryu",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/ryu/1.0.5/download",
-          "sha256": "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+          "url": "https://crates.io/api/v1/crates/ryu/1.0.6/download",
+          "sha256": "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
         }
       },
       "targets": [
@@ -4561,14 +4561,14 @@
         "deps": {
           "common": [
             {
-              "id": "ryu 1.0.5",
+              "id": "ryu 1.0.6",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.5"
+        "version": "1.0.6"
       },
       "build_script_attrs": {},
       "license": "Apache-2.0 OR BSL-1.0"
@@ -4859,7 +4859,7 @@
               "target": "itoa"
             },
             {
-              "id": "ryu 1.0.5",
+              "id": "ryu 1.0.6",
               "target": "ryu"
             },
             {

--- a/defs.bzl
+++ b/defs.bzl
@@ -192,14 +192,23 @@ Environment Variables:
                 "generate the value for this field. If unset, the defaults defined there will be used."
             ),
         ),
-        "rust_toolchain_repo_template": attr.string(
+        "rust_toolchain_cargo_template": attr.string(
             doc = (
-                "The template to use for finding the host `rust_toolchain` repository. `{version}` (eg. '1.53.0'), " +
+                "The template to use for finding the host `cargo` binary. `{version}` (eg. '1.53.0'), " +
                 "`{triple}` (eg. 'x86_64-unknown-linux-gnu'), `{arch}` (eg. 'aarch64'), `{vendor}` (eg. 'unknown'), " +
-                "`{system}` (eg. 'darwin'), `{cfg}` (eg. 'exec'), and `{tool}` (eg. 'rustc') will be replaced in the " +
-                "string if present."
+                "`{system}` (eg. 'darwin'), `{cfg}` (eg. 'exec'), and `{tool}` (eg. 'rustc.exe') will be replaced in " +
+                "the string if present."
             ),
-            default = "rust_{system}_{arch}",
+            default = "@rust_{system}_{arch}//:bin/{tool}",
+        ),
+        "rust_toolchain_rustc_template": attr.string(
+            doc = (
+                "The template to use for finding the host `rustc` binary. `{version}` (eg. '1.53.0'), " +
+                "`{triple}` (eg. 'x86_64-unknown-linux-gnu'), `{arch}` (eg. 'aarch64'), `{vendor}` (eg. 'unknown'), " +
+                "`{system}` (eg. 'darwin'), `{cfg}` (eg. 'exec'), and `{tool}` (eg. 'cargo.exe') will be replaced in " +
+                "the string if present."
+            ),
+            default = "@rust_{system}_{arch}//:bin/{tool}",
         ),
         "rust_version": attr.string(
             doc = "The version of Rust the currently registered toolchain is using. Eg. `1.56.0`, or `nightly-2021-09-08`",

--- a/deps.bzl
+++ b/deps.bzl
@@ -8,11 +8,11 @@ def cargo_bazel_deps():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "530b39273fb024c2cf885d8b997bac82980a530b47f05ed17b7b9b33b421b9f7",
-        strip_prefix = "rules_rust-57243dc7286b79eecd012809d446beef1fd0042e",
+        sha256 = "9dadbcd1136f7d4f3f2e7c0790531be0fdcccc535dec42a4c5a6f2df7380e3e3",
+        strip_prefix = "rules_rust-dc66c1612b7a3e96531eff22136570124c8eec81",
         urls = [
-            # `main` branch as of 2021-11-26
-            "https://github.com/bazelbuild/rules_rust/archive/57243dc7286b79eecd012809d446beef1fd0042e.tar.gz",
+            # `main` branch as of 2021-11-29
+            "https://github.com/bazelbuild/rules_rust/archive/dc66c1612b7a3e96531eff22136570124c8eec81.tar.gz",
         ],
     )
 

--- a/private/common_utils.bzl
+++ b/private/common_utils.bzl
@@ -66,7 +66,8 @@ def get_rust_tools(repository_ctx, host_triple):
 
     return _rust_get_rust_tools(
         repository_ctx = repository_ctx,
-        toolchain_repository_template = repository_ctx.attr.rust_toolchain_repo_template,
+        cargo_template = repository_ctx.attr.rust_toolchain_cargo_template,
+        rustc_template = repository_ctx.attr.rust_toolchain_rustc_template,
         host_triple = host_triple,
         version = repository_ctx.attr.rust_version,
     )


### PR DESCRIPTION
This should allow users who have custom [rust_toolchain](https://bazelbuild.github.io/rules_rust/flatten.html#rust_toolchain) implementations to express exactly where to get `rustc` and `cargo` binaries.