### PR TITLE
Fixed cargo builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Cargo configurations
+
+# The environment variables here are largly to allow Cargo builds
+# to compile. The targets built are expected to run under Bazel so
+# they many not function as expected based on the values here.
+[env]
+CARGO_BAZEL_BIN = "bazel-bin/tools/cargo_bazel/cargo_bazel"
+CROSS_BIN = "cross"
+CROSS_CONFIG = "tools/cross_installer/Cross.toml"
+DISTRO_ARCHIVE = "bazel-bin/distro/distro.tar.gz"
+EXAMPLES_PACKAGE = "examples"
+MODULE_ROOT_PATH = "private/urls.bzl"
+RUSTC = "rustc"

--- a/tools/cross_installer/BUILD.bazel
+++ b/tools/cross_installer/BUILD.bazel
@@ -13,7 +13,7 @@ rust_binary(
     ],
     proc_macro_deps = all_crate_deps(proc_macro = True),
     rustc_env = {
-        "CARGO_BIN": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
+        "CARGO": "$(rootpath @rules_rust//rust/toolchain:current_exec_cargo_files)",
         "CROSS_BIN": "$(rootpath :cross)",
         "CROSS_CONFIG": "$(rootpath :Cross.toml)",
     },

--- a/tools/cross_installer/src/main.rs
+++ b/tools/cross_installer/src/main.rs
@@ -28,7 +28,7 @@ fn prepare_workspace(workspace_root: &Path) {
 
     // Unfortunately, cross runs into issues when cross compiling incramentally.
     // To avoid this, the workspace must be cleaned
-    let cargo = env::current_dir().unwrap().join(env!("CARGO_BIN"));
+    let cargo = env::current_dir().unwrap().join(env!("CARGO"));
     Command::new(cargo)
         .current_dir(workspace_root)
         .arg("clean")


### PR DESCRIPTION
Maybe there should be a CI step to confirm cargo works on it's own but as of now `cargo test` does not work so I think there'd be additional work required to enable that job. For now, this allows users to `cargo build` to produce `cargo-bazel` vs `cargo build --bin cargo-bazel`.