### PR TITLE
Added a `CARGO_BAZEL_ISOLATED` environment variable for local dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ defaults:
 
 env:
   BAZEL_STARTUP_FLAGS: --bazelrc=${{ github.workspace }}/.github/github.bazelrc
+  CARGO_BAZEL_ISOLATED: true
 
 jobs:
   ci:

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -56,7 +56,6 @@ crates_repository(
         )],
     },
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
-    isolated = False,
     lockfile = "//:Cargo.Bazel.lock",
     manifests = [
         "//:Cargo.toml",

--- a/defs.bzl
+++ b/defs.bzl
@@ -13,8 +13,7 @@ load("@rules_rust//rust/platform:triple_mappings.bzl", "SUPPORTED_PLATFORM_TRIPL
 load("//private:common_utils.bzl", "get_host_triple", "get_rust_tools")
 load(
     "//private:generate_utils.bzl",
-    "GENERATOR_ENV_VARS",
-    "REPIN_ENV_VARS",
+    "CRATES_REPOSITORY_ENVIRON",
     "determine_repin",
     "execute_generator",
     "generate_config",
@@ -104,8 +103,9 @@ Environment Variables:
 
 | variable | usage |
 | --- | --- |
-| `CARGO_BAZEL_GENERATOR_URL` | The URL of a cargo-bazel binary. This variable takes precedence over attributes and can use `file://` for local paths |
 | `CARGO_BAZEL_GENERATOR_SHA256` | The sha256 checksum of the file located at `CARGO_BAZEL_GENERATOR_URL` |
+| `CARGO_BAZEL_GENERATOR_URL` | The URL of a cargo-bazel binary. This variable takes precedence over attributes and can use `file://` for local paths |
+| `CARGO_BAZEL_ISOLATED` | An authorative flag as to whether or not the `CARGO_HOME` environment variable should be isolated from the host configuration |
 | `CARGO_BAZEL_REPIN` | An indicator that the dependencies represented by the rule should be regenerated. `REPIN` may also be used. |
 
 """,
@@ -158,7 +158,8 @@ Environment Variables:
                 "If true, `CARGO_HOME` will be overwritten to a directory within the generated repository in " +
                 "order to prevent other uses of Cargo from impacting having any effect on the generated targets " +
                 "produced by this rule. For users who either have multiple `crate_repository` definitions in a " +
-                "WORKSPACE or rapidly re-pin dependencies, setting this to false may improve build times."
+                "WORKSPACE or rapidly re-pin dependencies, setting this to false may improve build times. This " +
+                "variable is also controled by `CARGO_BAZEL_ISOLATED` environment variable."
             ),
             default = True,
         ),
@@ -229,7 +230,7 @@ Environment Variables:
             default = SUPPORTED_PLATFORM_TRIPLES,
         ),
     },
-    environ = GENERATOR_ENV_VARS + REPIN_ENV_VARS,
+    environ = CRATES_REPOSITORY_ENVIRON,
 )
 
 def _workspace_member(version, sha256 = None):

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -21,10 +21,6 @@ load("@cargo_bazel//:defs.bzl", "crate", "crates_repository")
 
 crates_repository(
     name = "cargo_aliases",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//cargo_aliases:Cargo.Bazel.lock",
     manifests = ["//cargo_aliases:Cargo.toml"],
 )
@@ -42,10 +38,6 @@ cargo_aliases_crate_repositories()
 
 crates_repository(
     name = "crate_index_cargo_local",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//cargo_local:Cargo.lock",
     lockfile_kind = "cargo",
     manifests = ["//cargo_local:Cargo.toml"],
@@ -74,10 +66,6 @@ http_archive(
 
 crates_repository(
     name = "crate_index_cargo_remote",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "@names//:Cargo.lock",
     lockfile_kind = "cargo",
     manifests = ["@names//:Cargo.toml"],
@@ -96,10 +84,6 @@ cargo_remote_crate_repositories()
 
 crates_repository(
     name = "crate_index_cargo_workspace",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//cargo_workspace:Cargo.Bazel.lock",
     manifests = [
         "//cargo_workspace:Cargo.toml",
@@ -135,10 +119,6 @@ crates_repository(
         )],
     },
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//extra_workspace_members:Cargo.Bazel.lock",
     manifests = ["//extra_workspace_members:Cargo.toml"],
 )
@@ -197,10 +177,6 @@ crates_repository(
         )],
     },
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//multi_package:Cargo.Bazel.lock",
     manifests = [
         "//multi_package/pkg_a:Cargo.toml",
@@ -256,10 +232,6 @@ perl_register_toolchains()
 crates_repository(
     name = "no_cargo",
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",
-    # Since there are multiple `crate_repository` instances in this WORKSPACE
-    # file, it saves a ton of time to avoid isolation and allow them to share
-    # `CARGO_HOME`. This is also generally good for users rapidly re-pinning.
-    isolated = False,
     lockfile = "//no_cargo_manifests:Cargo.Bazel.lock",
     packages = {
         "axum": crate.spec(

--- a/private/generate_utils.bzl
+++ b/private/generate_utils.bzl
@@ -1,9 +1,9 @@
 """Utilities directly related to the `generate` step of `cargo-bazel`."""
 
-load(":common_utils.bzl", "cargo_home_path", "execute")
+load(":common_utils.bzl", "CARGO_BAZEL_ISOLATED", "cargo_environ", "execute")
 
-CARGO_BAZEL_GENERATOR_URL = "CARGO_BAZEL_GENERATOR_URL"
 CARGO_BAZEL_GENERATOR_SHA256 = "CARGO_BAZEL_GENERATOR_SHA256"
+CARGO_BAZEL_GENERATOR_URL = "CARGO_BAZEL_GENERATOR_URL"
 CARGO_BAZEL_REPIN = "CARGO_BAZEL_REPIN"
 REPIN = "REPIN"
 
@@ -15,6 +15,10 @@ GENERATOR_ENV_VARS = [
 REPIN_ENV_VARS = [
     REPIN,
     CARGO_BAZEL_REPIN,
+]
+
+CRATES_REPOSITORY_ENVIRON = GENERATOR_ENV_VARS + REPIN_ENV_VARS + [
+    CARGO_BAZEL_ISOLATED,
 ]
 
 def get_generator(repository_ctx, host_triple):
@@ -271,12 +275,8 @@ def determine_repin(repository_ctx, generator, lockfile_path, lockfile_kind, con
         "RUST_BACKTRACE": "full",
     }
 
-    # If isolated builds are enabled, restrict `CARGO_HOME` to a path
-    # within the generated repository rule.
-    if repository_ctx.attr.isolated:
-        env.update({
-            "CARGO_HOME": str(cargo_home_path(repository_ctx)),
-        })
+    # Add any Cargo environment variables to the `cargo-bazel` execution
+    env.update(cargo_environ(repository_ctx))
 
     result = execute(
         repository_ctx = repository_ctx,
@@ -365,12 +365,8 @@ def execute_generator(
             "RUSTC": str(rustc),
         })
 
-    # If isolated builds are enabled, restrict `CARGO_HOME` to a path
-    # within the generated repository rule.
-    if repository_ctx.attr.isolated:
-        env.update({
-            "CARGO_HOME": str(cargo_home_path(repository_ctx)),
-        })
+    # Add any Cargo environment variables to the `cargo-bazel` execution
+    env.update(cargo_environ(repository_ctx))
 
     result = execute(
         repository_ctx = repository_ctx,

--- a/private/splicing_utils.bzl
+++ b/private/splicing_utils.bzl
@@ -1,6 +1,6 @@
 """Utilities directly related to the `splicing` step of `cargo-bazel`."""
 
-load(":common_utils.bzl", "cargo_home_path", "execute")
+load(":common_utils.bzl", "cargo_environ", "execute")
 
 def download_extra_workspace_members(repository_ctx, cache_dir, render_template_registry_url):
     """Download additional workspace members for use in splicing.
@@ -161,12 +161,8 @@ def splice_workspace_manifest(repository_ctx, generator, lockfile, splicing_mani
         "RUST_BACKTRACE": "full",
     }
 
-    # If isolated builds are enabled, restrict `CARGO_HOME` to a path
-    # within the generated repository rule.
-    if repository_ctx.attr.isolated:
-        env.update({
-            "CARGO_HOME": str(cargo_home_path(repository_ctx)),
-        })
+    # Add any Cargo environment variables to the `cargo-bazel` execution
+    env.update(cargo_environ(repository_ctx))
 
     result = execute(
         repository_ctx = repository_ctx,

--- a/tools/examples_runner/src/main.rs
+++ b/tools/examples_runner/src/main.rs
@@ -106,6 +106,7 @@ fn main() {
         "CARGO_BAZEL_GENERATOR_SHA256".to_owned(),
         cargo_bazel_sha256,
     );
+    envs.insert("CARGO_BAZEL_ISOLATED".to_owned(), "true".to_owned());
 
     let startup_args = parse_startup_args();
 


### PR DESCRIPTION
This change allows users to use [--repo_env](https://docs.bazel.build/versions/main/command-line-reference.html#flag--repo_env) in their `user.bazelrc` files (see [best practices](https://docs.bazel.build/versions/main/best-practices.html#using-the-bazelrc-file)) to allow CI to always do the hermetic thing while local development can continue to iterate quickly.