### PR TITLE
Added support for patching crates

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "090e431d10d5020dab99783eab56e5fc39b10eebb168643f7fa1645346fa9eda",
+  "checksum": "1c80aeb8c873d57cd5057a4fe516bbc411550b482d13b6c2fdc05527f03b7dd7",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -115,13 +115,13 @@
       },
       "license": "MIT"
     },
-    "anyhow 1.0.51": {
+    "anyhow 1.0.52": {
       "name": "anyhow",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.51/download",
-          "sha256": "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.52/download",
+          "sha256": "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
         }
       },
       "targets": [
@@ -159,14 +159,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.51",
+              "id": "anyhow 1.0.52",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.51"
+        "version": "1.0.52"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -621,7 +621,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.51",
+              "id": "anyhow 1.0.52",
               "target": "anyhow"
             },
             {
@@ -637,7 +637,7 @@
               "target": "cargo_metadata"
             },
             {
-              "id": "cargo_toml 0.10.2",
+              "id": "cargo_toml 0.10.3",
               "target": "cargo_toml"
             },
             {
@@ -869,13 +869,13 @@
       },
       "license": "MIT"
     },
-    "cargo_toml 0.10.2": {
+    "cargo_toml 0.10.3": {
       "name": "cargo_toml",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cargo_toml/0.10.2/download",
-          "sha256": "67110a7844b75a4dda12f4dca5a731c961750d6c8fa3cb6a41ab67411be05d3a"
+          "url": "https://crates.io/api/v1/crates/cargo_toml/0.10.3/download",
+          "sha256": "363c7cfaa15f101415c4ac9e68706ca4a2277773932828b33f96e59d28c68e62"
         }
       },
       "targets": [
@@ -917,7 +917,7 @@
           ],
           "selects": {}
         },
-        "version": "0.10.2"
+        "version": "0.10.3"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -2090,7 +2090,7 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.14.0",
+              "id": "typenum 1.15.0",
               "target": "typenum"
             }
           ],
@@ -2145,7 +2145,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.14.0",
+              "id": "typenum 1.15.0",
               "target": "typenum"
             }
           ],
@@ -3622,15 +3622,15 @@
               "target": "pest_meta"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -3985,15 +3985,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -4071,11 +4071,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             }
           ],
@@ -4100,13 +4100,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.34": {
+    "proc-macro2 1.0.36": {
       "name": "proc-macro2",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.34/download",
-          "sha256": "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
+          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
         }
       },
       "targets": [
@@ -4144,7 +4144,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "build_script_build"
             },
             {
@@ -4155,7 +4155,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.34"
+        "version": "1.0.36"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4164,13 +4164,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.10": {
+    "quote 1.0.14": {
       "name": "quote",
-      "version": "1.0.10",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.10/download",
-          "sha256": "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.14/download",
+          "sha256": "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
         }
       },
       "targets": [
@@ -4196,14 +4196,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -4843,11 +4843,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
@@ -4855,7 +4855,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -5381,15 +5381,15 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -5400,13 +5400,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "syn 1.0.82": {
+    "syn 1.0.84": {
       "name": "syn",
-      "version": "1.0.82",
+      "version": "1.0.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.82/download",
-          "sha256": "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.84/download",
+          "sha256": "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
         }
       },
       "targets": [
@@ -5450,15 +5450,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "build_script_build"
             },
             {
@@ -5469,7 +5469,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.82"
+        "version": "1.0.84"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5954,13 +5954,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "typenum 1.14.0": {
+    "typenum 1.15.0": {
       "name": "typenum",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typenum/1.14.0/download",
-          "sha256": "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+          "url": "https://crates.io/api/v1/crates/typenum/1.15.0/download",
+          "sha256": "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
         }
       },
       "targets": [
@@ -5994,14 +5994,14 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.14.0",
+              "id": "typenum 1.15.0",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.14.0"
+        "version": "1.15.0"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/defs.bzl
+++ b/defs.bzl
@@ -297,6 +297,9 @@ def _extras(
         data_glob = None,
         deps = None,
         gen_build_script = None,
+        patch_args = None,
+        patch_tool = None,
+        patches = None,
         proc_macro_deps = None,
         rustc_env = None,
         rustc_env_files = None,
@@ -327,6 +330,12 @@ def _extras(
         deps (list, optional): A list of labels to add to a crate's `rust_library::deps` attribute.
         gen_build_script (bool, optional): An authorative flag to determine whether or not to produce
             `cargo_build_script` targets for the current crate.
+        patch_args (list, optional): The `patch_args` attribute of a Bazel repository rule. See
+            [http_archive.patch_args](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_args)
+        patch_tool (list, optional): The `patch_tool` attribute of a Bazel repository rule. See
+            [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)
+        patches (list, optional): The `patches` attribute of a Bazel repository rule. See
+            [http_archive.patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches)
         proc_macro_deps (list, optional): A list of labels to add to a crate's `rust_library::proc_macro_deps`
             attribute.
         rustc_env (dict, optional): Additional variables to set on a crate's `rust_library::rustc_env` attribute.
@@ -356,6 +365,9 @@ def _extras(
             data_glob = data_glob,
             deps = deps,
             gen_build_script = gen_build_script,
+            patch_args = patch_args,
+            patch_tool = patch_tool,
+            patches = patches,
             proc_macro_deps = proc_macro_deps,
             rustc_env = rustc_env,
             rustc_env_files = rustc_env_files,

--- a/examples/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "bf015999e5a553287d77f9e372d395a2a4657848a8300134d34e22c59198741d",
+  "checksum": "3e8080880ce83249ef57096fcf2be8fb71265b72761fc411d7ee462d2f56aa5b",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -207,11 +207,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -578,13 +578,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "proc-macro2 1.0.34": {
+    "proc-macro2 1.0.36": {
       "name": "proc-macro2",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.34/download",
-          "sha256": "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
+          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
         }
       },
       "targets": [
@@ -621,7 +621,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "build_script_build"
             },
             {
@@ -632,7 +632,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.34"
+        "version": "1.0.36"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -641,13 +641,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.10": {
+    "quote 1.0.14": {
       "name": "quote",
-      "version": "1.0.10",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.10/download",
-          "sha256": "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.14/download",
+          "sha256": "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
         }
       },
       "targets": [
@@ -673,14 +673,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -771,13 +771,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "syn 1.0.82": {
+    "syn 1.0.84": {
       "name": "syn",
-      "version": "1.0.82",
+      "version": "1.0.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.82/download",
-          "sha256": "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.84/download",
+          "sha256": "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
         }
       },
       "targets": [
@@ -818,15 +818,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "build_script_build"
             },
             {
@@ -837,7 +837,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.82"
+        "version": "1.0.84"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4f6c9bfdd72aba020c06d10d8bceee9e9e2cec6c0796159415eeb5495af1da12",
+  "checksum": "0a82afa66118d087bca354d39dba82e92d01d5c79a85f858e7dbae66a7311aa2",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -1669,15 +1669,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -1755,11 +1755,11 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             }
           ],
@@ -1784,13 +1784,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.34": {
+    "proc-macro2 1.0.36": {
       "name": "proc-macro2",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.34/download",
-          "sha256": "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
+          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
         }
       },
       "targets": [
@@ -1828,7 +1828,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "build_script_build"
             },
             {
@@ -1839,7 +1839,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.34"
+        "version": "1.0.36"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1848,13 +1848,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.10": {
+    "quote 1.0.14": {
       "name": "quote",
-      "version": "1.0.10",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.10/download",
-          "sha256": "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.14/download",
+          "sha256": "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
         }
       },
       "targets": [
@@ -1880,14 +1880,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2302,15 +2302,15 @@
               "target": "proc_macro_error"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -2321,13 +2321,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "syn 1.0.82": {
+    "syn 1.0.84": {
       "name": "syn",
-      "version": "1.0.82",
+      "version": "1.0.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.82/download",
-          "sha256": "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.84/download",
+          "sha256": "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
         }
       },
       "targets": [
@@ -2371,15 +2371,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "build_script_build"
             },
             {
@@ -2390,7 +2390,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.82"
+        "version": "1.0.84"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "9fa877f3b493f67efb51a78cc45b69f53e59c87d1426c691aa555d30dfe0e0fa",
+  "checksum": "f048fa7f54c6cb1b0648720ef889175450ea6f86a6322893459e25561b097595",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -44,13 +44,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "anyhow 1.0.51": {
+    "anyhow 1.0.52": {
       "name": "anyhow",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anyhow/1.0.51/download",
-          "sha256": "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+          "url": "https://crates.io/api/v1/crates/anyhow/1.0.52/download",
+          "sha256": "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
         }
       },
       "targets": [
@@ -88,14 +88,14 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.51",
+              "id": "anyhow 1.0.52",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.51"
+        "version": "1.0.52"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -864,15 +864,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -1803,11 +1803,11 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -2025,51 +2025,6 @@
         "version": "0.1.12"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "difference 2.0.0": {
-      "name": "difference",
-      "version": "2.0.0",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/difference/2.0.0/download",
-          "sha256": "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "difference",
-            "crate_root": "src/lib.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        },
-        {
-          "Binary": {
-            "crate_name": "difference",
-            "crate_root": "src/main.rs",
-            "srcs": {
-              "include": [
-                "**/*.rs"
-              ],
-              "exclude": []
-            }
-          }
-        }
-      ],
-      "library_target_name": "difference",
-      "common_attrs": {
-        "crate_features": [
-          "default"
-        ],
-        "edition": "2015",
-        "version": "2.0.0"
-      },
-      "license": "MIT"
     },
     "digest 0.9.0": {
       "name": "digest",
@@ -2876,15 +2831,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -3139,7 +3094,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "typenum 1.14.0",
+              "id": "typenum 1.15.0",
               "target": "typenum"
             }
           ],
@@ -3648,13 +3603,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "httpmock 0.6.4": {
+    "httpmock 0.6.5": {
       "name": "httpmock",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/httpmock/0.6.4/download",
-          "sha256": "67fc2a6377230dc7cc007c74c34665f92589b4a73ed503f1c91ede8de6df35f0"
+          "url": "https://crates.io/api/v1/crates/httpmock/0.6.5/download",
+          "sha256": "a24a520a3193799852cc4baf0d8356d7578a8847dfc5603d087529f099661e42"
         }
       },
       "targets": [
@@ -3708,10 +3663,6 @@
               "target": "crossbeam_utils"
             },
             {
-              "id": "difference 2.0.0",
-              "target": "difference"
-            },
-            {
               "id": "form_urlencoded 1.0.1",
               "target": "form_urlencoded"
             },
@@ -3760,6 +3711,10 @@
               "target": "serde_regex"
             },
             {
+              "id": "similar 2.1.0",
+              "target": "similar"
+            },
+            {
               "id": "tokio 1.15.0",
               "target": "tokio"
             }
@@ -3776,7 +3731,7 @@
           ],
           "selects": {}
         },
-        "version": "0.6.4"
+        "version": "0.6.5"
       },
       "license": "MIT"
     },
@@ -6137,13 +6092,13 @@
       },
       "license": "MIT"
     },
-    "pin-project 1.0.8": {
+    "pin-project 1.0.9": {
       "name": "pin-project",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project/1.0.8/download",
-          "sha256": "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+          "url": "https://crates.io/api/v1/crates/pin-project/1.0.9/download",
+          "sha256": "1622113ce508488160cff04e6abc60960e676d330e1ca0f77c0b8df17c81438f"
         }
       },
       "targets": [
@@ -6166,23 +6121,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pin-project-internal 1.0.8",
+              "id": "pin-project-internal 1.0.9",
               "target": "pin_project_internal"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.8"
+        "version": "1.0.9"
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "pin-project-internal 1.0.8": {
+    "pin-project-internal 1.0.9": {
       "name": "pin-project-internal",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.0.8/download",
-          "sha256": "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.0.9/download",
+          "sha256": "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
         }
       },
       "targets": [
@@ -6204,22 +6159,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.8"
+        "version": "1.0.9"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -6336,7 +6291,7 @@
         "deps": {
           "common": [
             {
-              "id": "anyhow 1.0.51",
+              "id": "anyhow 1.0.52",
               "target": "anyhow"
             },
             {
@@ -6349,7 +6304,7 @@
         "deps_dev": {
           "common": [
             {
-              "id": "httpmock 0.6.4",
+              "id": "httpmock 0.6.5",
               "target": "httpmock"
             }
           ],
@@ -6565,13 +6520,13 @@
       },
       "license": "MIT"
     },
-    "proc-macro2 1.0.34": {
+    "proc-macro2 1.0.36": {
       "name": "proc-macro2",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.34/download",
-          "sha256": "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
+          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
         }
       },
       "targets": [
@@ -6609,7 +6564,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "build_script_build"
             },
             {
@@ -6620,7 +6575,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.34"
+        "version": "1.0.36"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6668,13 +6623,13 @@
       },
       "license": "MIT"
     },
-    "quote 1.0.10": {
+    "quote 1.0.14": {
       "name": "quote",
-      "version": "1.0.10",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.10/download",
-          "sha256": "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.14/download",
+          "sha256": "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
         }
       },
       "targets": [
@@ -6700,14 +6655,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7679,11 +7634,11 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
@@ -7691,7 +7646,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -7980,6 +7935,40 @@
       },
       "license": "Apache-2.0/MIT"
     },
+    "similar 2.1.0": {
+      "name": "similar",
+      "version": "2.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/similar/2.1.0/download",
+          "sha256": "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "similar",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "similar",
+      "common_attrs": {
+        "crate_features": [
+          "default",
+          "text"
+        ],
+        "edition": "2018",
+        "version": "2.1.0"
+      },
+      "license": "Apache-2.0"
+    },
     "siphasher 0.3.7": {
       "name": "siphasher",
       "version": "0.3.7",
@@ -8230,13 +8219,13 @@
       },
       "license": "MIT / Apache-2.0"
     },
-    "syn 1.0.82": {
+    "syn 1.0.84": {
       "name": "syn",
-      "version": "1.0.82",
+      "version": "1.0.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.82/download",
-          "sha256": "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.84/download",
+          "sha256": "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
         }
       },
       "targets": [
@@ -8283,15 +8272,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "build_script_build"
             },
             {
@@ -8302,7 +8291,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.82"
+        "version": "1.0.84"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8708,15 +8697,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -8958,15 +8947,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -9053,7 +9042,7 @@
         "deps": {
           "common": [
             {
-              "id": "pin-project 1.0.8",
+              "id": "pin-project 1.0.9",
               "target": "pin_project"
             },
             {
@@ -9098,13 +9087,13 @@
       },
       "license": "MIT"
     },
-    "typenum 1.14.0": {
+    "typenum 1.15.0": {
       "name": "typenum",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/typenum/1.14.0/download",
-          "sha256": "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+          "url": "https://crates.io/api/v1/crates/typenum/1.15.0/download",
+          "sha256": "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
         }
       },
       "targets": [
@@ -9138,14 +9127,14 @@
         "deps": {
           "common": [
             {
-              "id": "typenum 1.14.0",
+              "id": "typenum 1.15.0",
               "target": "build_script_main"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.14.0"
+        "version": "1.15.0"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9674,15 +9663,15 @@
               "target": "log"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             },
             {
@@ -9782,7 +9771,7 @@
         "deps": {
           "common": [
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
@@ -9828,15 +9817,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             },
             {
@@ -10313,8 +10302,7 @@
   },
   "binary_crates": [
     "cc 1.0.72",
-    "difference 2.0.0",
-    "httpmock 0.6.4",
+    "httpmock 0.6.5",
     "lalrpop 0.19.6"
   ],
   "workspace_members": {

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "be65902420b8142874a61e177817b820d259ed3eab42e2e9f9cadee313ad9cfc",
+  "checksum": "69ce533d358f68dc56475d2db45b5f85dc7c16903142e1e899c4dd131b7b3c4b",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -129,15 +129,15 @@
               "target": "build_script_build"
             },
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -2397,13 +2397,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "pin-project 1.0.8": {
+    "pin-project 1.0.9": {
       "name": "pin-project",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project/1.0.8/download",
-          "sha256": "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+          "url": "https://crates.io/api/v1/crates/pin-project/1.0.9/download",
+          "sha256": "1622113ce508488160cff04e6abc60960e676d330e1ca0f77c0b8df17c81438f"
         }
       },
       "targets": [
@@ -2426,23 +2426,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "pin-project-internal 1.0.8",
+              "id": "pin-project-internal 1.0.9",
               "target": "pin_project_internal"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.8"
+        "version": "1.0.9"
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "pin-project-internal 1.0.8": {
+    "pin-project-internal 1.0.9": {
       "name": "pin-project-internal",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.0.8/download",
-          "sha256": "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+          "url": "https://crates.io/api/v1/crates/pin-project-internal/1.0.9/download",
+          "sha256": "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
         }
       },
       "targets": [
@@ -2464,22 +2464,22 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.8"
+        "version": "1.0.9"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -2543,13 +2543,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "proc-macro2 1.0.34": {
+    "proc-macro2 1.0.36": {
       "name": "proc-macro2",
-      "version": "1.0.34",
+      "version": "1.0.36",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.34/download",
-          "sha256": "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+          "url": "https://crates.io/api/v1/crates/proc-macro2/1.0.36/download",
+          "sha256": "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
         }
       },
       "targets": [
@@ -2587,7 +2587,7 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "build_script_build"
             },
             {
@@ -2598,7 +2598,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.34"
+        "version": "1.0.36"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2607,13 +2607,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "quote 1.0.10": {
+    "quote 1.0.14": {
       "name": "quote",
-      "version": "1.0.10",
+      "version": "1.0.14",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/quote/1.0.10/download",
-          "sha256": "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+          "url": "https://crates.io/api/v1/crates/quote/1.0.14/download",
+          "sha256": "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
         }
       },
       "targets": [
@@ -2639,14 +2639,14 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.10"
+        "version": "1.0.14"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3272,13 +3272,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "syn 1.0.82": {
+    "syn 1.0.84": {
       "name": "syn",
-      "version": "1.0.82",
+      "version": "1.0.84",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/1.0.82/download",
-          "sha256": "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+          "url": "https://crates.io/api/v1/crates/syn/1.0.84/download",
+          "sha256": "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
         }
       },
       "targets": [
@@ -3325,15 +3325,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "build_script_build"
             },
             {
@@ -3344,7 +3344,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.82"
+        "version": "1.0.84"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3564,15 +3564,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],
@@ -3693,7 +3693,7 @@
               "target": "futures_util"
             },
             {
-              "id": "pin-project 1.0.8",
+              "id": "pin-project 1.0.9",
               "target": "pin_project"
             },
             {
@@ -3783,7 +3783,7 @@
               "target": "http_body"
             },
             {
-              "id": "pin-project 1.0.8",
+              "id": "pin-project 1.0.9",
               "target": "pin_project"
             },
             {
@@ -3961,15 +3961,15 @@
         "deps": {
           "common": [
             {
-              "id": "proc-macro2 1.0.34",
+              "id": "proc-macro2 1.0.36",
               "target": "proc_macro2"
             },
             {
-              "id": "quote 1.0.10",
+              "id": "quote 1.0.14",
               "target": "quote"
             },
             {
-              "id": "syn 1.0.82",
+              "id": "syn 1.0.84",
               "target": "syn"
             }
           ],

--- a/tools/cargo_bazel/src/annotation.rs
+++ b/tools/cargo_bazel/src/annotation.rs
@@ -95,12 +95,27 @@ pub enum SourceAnnotation {
     Git {
         remote: String,
         commitish: Commitish,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         shallow_since: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         strip_prefix: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patch_args: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patch_tool: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patches: Option<BTreeSet<String>>,
     },
     Http {
         url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         sha256: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patch_args: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patch_tool: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        patches: Option<BTreeSet<String>>,
     },
 }
 
@@ -170,6 +185,9 @@ impl LockfileAnnotation {
                     return Ok(SourceAnnotation::Http {
                         url: info.url,
                         sha256: Some(info.sha256),
+                        patch_args: None,
+                        patch_tool: None,
+                        patches: None,
                     })
                 }
                 None => bail!(
@@ -189,6 +207,9 @@ impl LockfileAnnotation {
                 commitish: Commitish::from(git_ref.clone()),
                 shallow_since: None,
                 strip_prefix,
+                patch_args: None,
+                patch_tool: None,
+                patches: None,
             });
         }
 
@@ -198,6 +219,9 @@ impl LockfileAnnotation {
             return Ok(SourceAnnotation::Http {
                 url: info.url,
                 sha256: Some(info.sha256),
+                patch_args: None,
+                patch_tool: None,
+                patches: None,
             });
         }
 
@@ -222,6 +246,9 @@ impl LockfileAnnotation {
                         }
                     })
                     .map(|sum| sum.encode_hex::<String>()),
+                patch_args: None,
+                patch_tool: None,
+                patches: None,
             });
         }
 

--- a/tools/cargo_bazel/src/config.rs
+++ b/tools/cargo_bazel/src/config.rs
@@ -173,6 +173,18 @@ pub struct CrateExtras {
     /// For git sourced crates, this is a the
     /// [git_repository::shallow_since](https://docs.bazel.build/versions/main/repo/git.html#new_git_repository-shallow_since) attribute.
     pub shallow_since: Option<String>,
+
+    /// The `patch_args` attribute of a Bazel repository rule. See
+    /// [http_archive.patch_args](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_args)
+    pub patch_args: Option<Vec<String>>,
+
+    /// The `patch_tool` attribute of a Bazel repository rule. See
+    /// [http_archive.patch_tool](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patch_tool)
+    pub patch_tool: Option<String>,
+
+    /// The `patches` attribute of a Bazel repository rule. See
+    /// [http_archive.patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches)
+    pub patches: Option<BTreeSet<String>>,
 }
 
 macro_rules! joined_extra_member {
@@ -202,6 +214,14 @@ impl Add for CrateExtras {
             self.shallow_since
         } else if rhs.shallow_since.is_some() {
             rhs.shallow_since
+        } else {
+            None
+        };
+
+        let patch_tool = if self.patch_tool.is_some() {
+            self.patch_tool
+        } else if rhs.patch_tool.is_some() {
+            rhs.patch_tool
         } else {
             None
         };
@@ -240,6 +260,9 @@ impl Add for CrateExtras {
             build_script_rustc_env: joined_extra_member!(self.build_script_rustc_env, rhs.build_script_rustc_env, BTreeMap::new, BTreeMap::extend),
             build_content: joined_extra_member!(self.build_content, rhs.build_content, String::new, concat_string),
             shallow_since,
+            patch_args: joined_extra_member!(self.patch_args, rhs.patch_args, Vec::new, Vec::extend),
+            patch_tool,
+            patches: joined_extra_member!(self.patches, rhs.patches, BTreeSet::new, BTreeSet::extend),
         };
 
         output

--- a/tools/cargo_bazel/src/context/crate_context.rs
+++ b/tools/cargo_bazel/src/context/crate_context.rs
@@ -457,6 +457,32 @@ impl CrateContext {
             if let Some(SourceAnnotation::Git { shallow_since, .. }) = &mut self.repository {
                 *shallow_since = crate_extra.shallow_since.clone()
             }
+
+            // Patch attributes
+            if let Some(repository) = &mut self.repository {
+                match repository {
+                    SourceAnnotation::Git {
+                        patch_args,
+                        patch_tool,
+                        patches,
+                        ..
+                    } => {
+                        *patch_args = crate_extra.patch_args.clone();
+                        *patch_tool = crate_extra.patch_tool.clone();
+                        *patches = crate_extra.patches.clone();
+                    }
+                    SourceAnnotation::Http {
+                        patch_args,
+                        patch_tool,
+                        patches,
+                        ..
+                    } => {
+                        *patch_args = crate_extra.patch_args.clone();
+                        *patch_tool = crate_extra.patch_tool.clone();
+                        *patches = crate_extra.patches.clone();
+                    }
+                }
+            }
         }
 
         self

--- a/tools/cargo_bazel/src/lockfile.rs
+++ b/tools/cargo_bazel/src/lockfile.rs
@@ -279,7 +279,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("97bdba06aebe43d3771bc5982b986a0c039aeb4b56ec9ef09c6e372942747e2a".to_owned())
+            Digest("0902892caf6718160f6597212db6367fd73bd67e76474d3ffa4bff3a8ed88f96".to_owned())
         );
     }
 

--- a/tools/cargo_bazel/src/rendering/templates/partials/module/repo_git.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/module/repo_git.j2
@@ -13,7 +13,24 @@
     {%- endif %}
     {%- endfor %}
         init_submodules = True,
-    {%- if attrs.shallow_since %}
+    {%- if attrs | get(key="patch_args", default=Null) %}
+        patch_args = [
+    {%- for arg in attrs.patch_args %}
+            "{{ arg }}",
+    {%- endfor %}
+        ],
+    {%- endif %}
+    {%- if attrs | get(key="patch_tool", default=Null) %}
+        patch_tool = "{{ attrs.patch_tool }}",
+    {%- endif %}
+    {%- if attrs | get(key="patches", default=Null) %}
+        patches = [
+    {%- for patch in attrs.patches %}
+            "{{ patch }}",
+    {%- endfor %}
+        ],
+    {%- endif %}
+    {%- if attrs | get(key="shallow_since", default=Null) %}
         shallow_since = "{{ attrs.shallow_since }}",
     {%- endif %}
         remote = "{{ attrs.remote }}",

--- a/tools/cargo_bazel/src/rendering/templates/partials/module/repo_http.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/module/repo_http.j2
@@ -1,7 +1,24 @@
     maybe(
         http_archive,
         name = "{{ crate_repository(name = crate.name, version = crate.version) }}",
-    {%- if attrs.sha256 %}
+    {%- if attrs | get(key="patch_args", default=Null) %}
+        patch_args = [
+    {%- for arg in attrs.patch_args %}
+            "{{ arg }}",
+    {%- endfor %}
+        ],
+    {%- endif %}
+    {%- if attrs | get(key="patch_tool", default=Null) %}
+        patch_tool = "{{ attrs.patch_tool }}",
+    {%- endif %}
+    {%- if attrs | get(key="patches", default=Null) %}
+        patches = [
+    {%- for patch in attrs.patches %}
+            "{{ patch }}",
+    {%- endfor %}
+        ],
+    {%- endif %}
+    {%- if attrs | get(key="sha256", default=Null) %}
         sha256 = "{{ attrs.sha256 }}",
     {%- endif %}
         type = "tar.gz",


### PR DESCRIPTION
This PR allows users to apply [patches](https://docs.bazel.build/versions/main/repo/http.html#http_archive-patches) to crates. This can be very useful as some crates have been written in ways that work just fine in Cargo but create big headaches in Bazel. Patches can now be used to solve for these headaches.
