### PR TITLE
Reduce calls to Bazel in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,14 +87,6 @@ jobs:
         if: startswith(matrix.os, 'Windows')
 
       # Build and Test the code
-      - name: Build
-        run: |
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            bazel ${BAZEL_STARTUP_FLAGS[@]} build ///...
-          else
-            bazel ${BAZEL_STARTUP_FLAGS[@]} build //...
-          fi
-
       - name: Test
         run: |
           if [[ "${RUNNER_OS}" == "Windows" ]]; then

--- a/tools/examples_runner/src/main.rs
+++ b/tools/examples_runner/src/main.rs
@@ -110,15 +110,7 @@ fn main() {
 
     let startup_args = parse_startup_args();
 
-    // Build all targets
-    execute_bazel(
-        &startup_args,
-        &["build", "//...", override_repo.as_str()],
-        &examples_dir,
-        &envs,
-    );
-
-    // Test all targets
+    // Build and test all targets
     execute_bazel(
         &startup_args,
         &["test", "//...", override_repo.as_str()],
@@ -129,15 +121,7 @@ fn main() {
     // Update the environment
     envs.insert("CARGO_BAZEL_REPIN".to_owned(), "true".to_owned());
 
-    // Build all targets while repinning
-    execute_bazel(
-        &startup_args,
-        &["build", "//...", override_repo.as_str()],
-        &examples_dir,
-        &envs,
-    );
-
-    // Test all targets
+    // Build and test all targets while repinning
     execute_bazel(
         &startup_args,
         &["test", "//...", override_repo.as_str()],


### PR DESCRIPTION
`bazel build //... && bazel test //...` is the same as `bazel test //...`. There's no need to constantly call both.