### PR TITLE
Avoid using subshells

### DIFF
--- a/private/test/BUILD.bazel
+++ b/private/test/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 diff_test(
     name = "srcs_diff_test",
-    failure_message = "Please run `bazel run @cargo_bazel//private:srcs_module.install`",
+    failure_message = "Please run 'bazel run @cargo_bazel//private:srcs_module.install'",
     file1 = "//private:srcs_module",
     file2 = "//private:srcs.bzl",
     # TODO: The diff_test here fails on Windows. As does the


### PR DESCRIPTION
There's a bug in `@bazel_skylib//rules:diff_tool.bzl` that causes the use of back ticks here to actually become subshell commands. This avoids that issue.