### PR TITLE
Minor cleanup to avoid returning `repository_ctx.path` where unnecessary

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -49,6 +49,8 @@ def _crates_repository_impl(repository_ctx):
 
     # Locate Rust tools (cargo, rustc)
     tools = get_rust_tools(repository_ctx, host_triple)
+    cargo_path = repository_ctx.path(tools.cargo)
+    rustc_path = repository_ctx.path(tools.rustc)
 
     # Create a manifest of all dependency inputs
     splicing_manifest = create_splicing_manifest(repository_ctx)
@@ -61,8 +63,8 @@ def _crates_repository_impl(repository_ctx):
         lockfile_kind = lockfile.kind,
         config = config.path,
         splicing_manifest = splicing_manifest,
-        cargo_path = tools.cargo,
-        rustc_path = tools.rustc,
+        cargo = cargo_path,
+        rustc = rustc_path,
     )
 
     # If re-pinning is enabled, gather additional inputs for the generator
@@ -74,8 +76,8 @@ def _crates_repository_impl(repository_ctx):
             generator = generator,
             lockfile = lockfile,
             splicing_manifest = splicing_manifest,
-            cargo = tools.cargo,
-            rustc = tools.rustc,
+            cargo = cargo_path,
+            rustc = rustc_path,
         )
 
         kwargs.update({
@@ -92,8 +94,8 @@ def _crates_repository_impl(repository_ctx):
         lockfile_path = lockfile.path,
         lockfile_kind = lockfile.kind,
         repository_dir = repository_ctx.path("."),
-        cargo = tools.cargo,
-        rustc = tools.rustc,
+        cargo = cargo_path,
+        rustc = rustc_path,
         # sysroot = tools.sysroot,
         **kwargs
     )

--- a/private/generate_utils.bzl
+++ b/private/generate_utils.bzl
@@ -227,7 +227,7 @@ def get_lockfile(repository_ctx):
         kind = kind,
     )
 
-def determine_repin(repository_ctx, generator, lockfile_path, lockfile_kind, config, splicing_manifest, cargo_path, rustc_path):
+def determine_repin(repository_ctx, generator, lockfile_path, lockfile_kind, config, splicing_manifest, cargo, rustc):
     """Use the `cargo-bazel` binary to determine whether or not dpeendencies need to be re-pinned
 
     Args:
@@ -237,8 +237,8 @@ def determine_repin(repository_ctx, generator, lockfile_path, lockfile_kind, con
         splicing_manifest (path): The path to a `cargo-bazel` splicing manifest. See `create_splicing_manifest`
         lockfile_path (path): The path to a "lock" file for reproducible outputs.
         lockfile_kind (str): The type of lock file represented by `lockfile_path`
-        cargo_path (path): The path to a Cargo binary.
-        rustc_path (path): The path to a Rustc binary.
+        cargo (path): The path to a Cargo binary.
+        rustc (path): The path to a Rustc binary.
 
     Returns:
         bool: True if dependencies need to be re-pinned
@@ -264,14 +264,14 @@ def determine_repin(repository_ctx, generator, lockfile_path, lockfile_kind, con
         "--splicing-manifest",
         splicing_manifest,
         "--cargo",
-        cargo_path,
+        cargo,
         "--rustc",
-        rustc_path,
+        rustc,
     ]
 
     env = {
-        "CARGO": str(cargo_path),
-        "RUSTC": str(rustc_path),
+        "CARGO": str(cargo),
+        "RUSTC": str(rustc),
         "RUST_BACKTRACE": "full",
     }
 

--- a/private/rust_utils.bzl
+++ b/private/rust_utils.bzl
@@ -20,7 +20,7 @@ def _query_cpu_architecture(repository_ctx, expected_archs, is_windows = False):
         is_windows (bool, optional): If true, the cpu lookup will use the windows method (`wmic` vs `uname`)
 
     Returns:
-        string: The host's CPU architecture
+        str: The host's CPU architecture
     """
     if is_windows:
         arguments = ["wmic", "os", "get", "osarchitecture"]
@@ -104,7 +104,7 @@ def get_host_triple(repository_ctx, abi = None):
 
     fail("Unhandled host os: {}", repository_ctx.os.name)
 
-def resolve_repository_template(
+def _resolve_repository_template(
         template,
         version = None,
         triple = None,
@@ -157,28 +157,22 @@ def resolve_repository_template(
 
     return template
 
-def get_rust_tools(
-        repository_ctx,
-        cargo_template,
-        rustc_template,
-        host_triple,
-        version):
-    """Retrieve a cargo and rustc binary based on the host triple.
+def get_rust_tools(repository_ctx, cargo_template, rustc_template, host_triple, version):
+    """Retrieve `cargo` and `rustc` labels based on the host triple.
 
     Args:
         repository_ctx (repository_ctx): The rule's context object
-        cargo_template (str): A template used to identify the host `cargo` binary.
-        rustc_template (str): A template used to identify the host `cargo` binary.
+        cargo_template (str): A template used to identify the label of the host `cargo` binary.
+        rustc_template (str): A template used to identify the label of the host `rustc` binary.
         host_triple (struct): The host's triple. See `@rules_rust//rust/platform:triple.bzl`.
         version (str): The version of Cargo+Rustc to use.
 
     Returns:
-        struct: A struct containing the expected tools
+        struct: A struct containing the labels of expected tools
     """
-
     extension = system_to_binary_ext(host_triple.system)
 
-    cargo_label = Label(resolve_repository_template(
+    cargo_label = Label(_resolve_repository_template(
         template = cargo_template,
         version = version,
         triple = host_triple.triple,
@@ -190,7 +184,7 @@ def get_rust_tools(
         cfg = "exec",
     ))
 
-    rustc_label = Label(resolve_repository_template(
+    rustc_label = Label(_resolve_repository_template(
         template = rustc_template,
         version = version,
         triple = host_triple.triple,
@@ -202,10 +196,7 @@ def get_rust_tools(
         cfg = "exec",
     ))
 
-    cargo_path = repository_ctx.path(cargo_label)
-    rustc_path = repository_ctx.path(rustc_label)
-
     return struct(
-        cargo = cargo_path,
-        rustc = rustc_path,
+        cargo = cargo_label,
+        rustc = rustc_label,
     )


### PR DESCRIPTION
This is a minor cleanup. I first thought there was an issue where `rustc` and `cargo` were being fetched unnecessarily but instead, there's no path that doesn't need them available. This cleans up some utility functions to return labels instead of paths though to try and avoid issues in the future where they might get pulled unnecessarily.