### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "902becd1c3b56db1e4981257e9250a42ff1878d3c9b33a43c2086719eb6d531a",
+  "checksum": "201d8a46a677ecca5f3e3f00a1b22b12031b21bb147d03bad737a3a7586ee2df",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -170,7 +170,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -529,7 +529,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -596,7 +596,7 @@
               "target": "cargo_metadata"
             },
             {
-              "id": "cargo_toml 0.11.0",
+              "id": "cargo_toml 0.11.1",
               "target": "cargo_toml"
             },
             {
@@ -604,7 +604,7 @@
               "target": "cfg_expr"
             },
             {
-              "id": "clap 3.0.10",
+              "id": "clap 3.0.12",
               "target": "clap"
             },
             {
@@ -628,7 +628,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -712,7 +712,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -759,7 +759,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -813,7 +813,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -828,16 +828,13 @@
       },
       "license": "MIT"
     },
-    "cargo_toml 0.11.0": {
+    "cargo_toml 0.11.1": {
       "name": "cargo_toml",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "repository": {
-        "Git": {
-          "remote": "https://gitlab.com/crates.rs/cargo_toml.git",
-          "commitish": {
-            "Rev": "78b84638c89dc699923802a9b414b01b69b3417e"
-          },
-          "shallow_since": "1642953712 +0000"
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/cargo_toml/0.11.1/download",
+          "sha256": "5cc7aa568f9b7e9d7865dee91157e45cb45378635590f11898f7d2bdbd425208"
         }
       },
       "targets": [
@@ -859,7 +856,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -873,13 +870,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "0.11.0"
+        "version": "0.11.1"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -1044,7 +1041,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -1195,13 +1192,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "clap 3.0.10": {
+    "clap 3.0.12": {
       "name": "clap",
-      "version": "3.0.10",
+      "version": "3.0.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/3.0.10/download",
-          "sha256": "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+          "url": "https://crates.io/api/v1/crates/clap/3.0.12/download",
+          "sha256": "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
         }
       },
       "targets": [
@@ -1277,23 +1274,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 3.0.6",
+              "id": "clap_derive 3.0.12",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "3.0.10"
+        "version": "3.0.12"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 3.0.6": {
+    "clap_derive 3.0.12": {
       "name": "clap_derive",
-      "version": "3.0.6",
+      "version": "3.0.12",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_derive/3.0.6/download",
-          "sha256": "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+          "url": "https://crates.io/api/v1/crates/clap_derive/3.0.12/download",
+          "sha256": "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
         }
       },
       "targets": [
@@ -1344,7 +1341,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "3.0.6"
+        "version": "3.0.12"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1378,7 +1375,7 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -1437,7 +1434,7 @@
               "target": "semver"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -1455,7 +1452,7 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "serde_derive"
             }
           ],
@@ -1552,7 +1549,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.0.10",
+              "id": "clap 3.0.12",
               "target": "clap"
             }
           ],
@@ -1993,7 +1990,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -2051,7 +2048,7 @@
               "target": "crc32fast"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -2295,7 +2292,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -2338,7 +2335,7 @@
               "target": "bitflags"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -2560,7 +2557,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -2605,7 +2602,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -2790,7 +2787,7 @@
               "target": "same_file"
             },
             {
-              "id": "thread_local 1.1.3",
+              "id": "thread_local 1.1.4",
               "target": "thread_local"
             },
             {
@@ -2983,7 +2980,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -3024,13 +3021,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -3068,14 +3065,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3112,7 +3109,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -3161,7 +3158,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -4528,7 +4525,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -4975,7 +4972,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -4991,13 +4988,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.135": {
+    "serde 1.0.136": {
       "name": "serde",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.135/download",
-          "sha256": "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.136/download",
+          "sha256": "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
         }
       },
       "targets": [
@@ -5038,7 +5035,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "build_script_build"
             }
           ],
@@ -5048,13 +5045,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.135"
+        "version": "1.0.136"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5063,13 +5060,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.135": {
+    "serde_derive 1.0.136": {
       "name": "serde_derive",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.135/download",
-          "sha256": "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.136/download",
+          "sha256": "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
         }
       },
       "targets": [
@@ -5114,7 +5111,7 @@
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "build_script_build"
             },
             {
@@ -5125,7 +5122,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.135"
+        "version": "1.0.136"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -5187,7 +5184,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -5448,7 +5445,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -5670,7 +5667,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               },
               {
@@ -5728,7 +5725,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -5828,7 +5825,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -5954,13 +5951,13 @@
       },
       "license": "MIT"
     },
-    "thread_local 1.1.3": {
+    "thread_local 1.1.4": {
       "name": "thread_local",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thread_local/1.1.3/download",
-          "sha256": "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+          "url": "https://crates.io/api/v1/crates/thread_local/1.1.4/download",
+          "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
         }
       },
       "targets": [
@@ -5989,7 +5986,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.1.3"
+        "version": "1.1.4"
       },
       "license": "Apache-2.0/MIT"
     },
@@ -6098,7 +6095,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -6784,7 +6781,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 3.0.10",
+              "id": "clap 3.0.12",
               "target": "clap"
             },
             {
@@ -7221,7 +7218,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,8 +167,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.11.0"
-source = "git+https://gitlab.com/crates.rs/cargo_toml.git?rev=78b84638c89dc699923802a9b414b01b69b3417e#78b84638c89dc699923802a9b414b01b69b3417e"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc7aa568f9b7e9d7865dee91157e45cb45378635590f11898f7d2bdbd425208"
 dependencies = [
  "serde",
  "serde_derive",
@@ -235,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
 dependencies = [
  "atty",
  "bitflags",
@@ -252,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -600,9 +601,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
 
 [[package]]
 name = "libgit2-sys"
@@ -963,18 +964,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.135"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1144,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -19,9 +19,6 @@ load("//:defs.bzl", "crate", "crates_repository")
 crates_repository(
     name = "crate_index",
     annotations = {
-        "cargo_toml": [crate.annotation(
-            shallow_since = "1642953712 +0000",
-        )],
         "chrono-tz": [crate.annotation(
             build_script_data_glob = ["**/tz/**"],
         )],

--- a/deps.bzl
+++ b/deps.bzl
@@ -8,11 +8,11 @@ def cargo_bazel_deps():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "b284b39cf62ef9584ec7e2a1fdefadbebf5c254ff8f57636d8fd8aa80042d83e",
-        strip_prefix = "rules_rust-77285c1aaebc1c55e6e80acc27be4c54aa30076d",
+        sha256 = "6c26af1bb98276917fcf29ea942615ab375cf9d3c52f15c27fdd176ced3ee906",
+        strip_prefix = "rules_rust-b3ddf6f096887b757ab1a661662a95d6b2699fa7",
         urls = [
-            # `main` branch as of 2022-01-21
-            "https://github.com/bazelbuild/rules_rust/archive/77285c1aaebc1c55e6e80acc27be4c54aa30076d.tar.gz",
+            # `main` branch as of 2022-01-24
+            "https://github.com/bazelbuild/rules_rust/archive/b3ddf6f096887b757ab1a661662a95d6b2699fa7.tar.gz",
         ],
     )
 

--- a/deps_bootstrap.bzl
+++ b/deps_bootstrap.bzl
@@ -17,4 +17,6 @@ def cargo_bazel_bootstrap(name = "cargo_bazel_bootstrap", rust_version = None):
         cargo_lockfile = "@cargo_bazel//:Cargo.lock",
         cargo_toml = "@cargo_bazel//:Cargo.toml",
         version = rust_version,
+        # The increased timeout helps avoid flakes in CI
+        timeout = 900,
     )

--- a/examples/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d32d9307eadc379b7517477f496703b0106a8c57adf72da222a1ddbfd04c1481",
+  "checksum": "f2f041710ee37102c7b23374c66bf1d3ff576809e2cf692d7ef2fefa7ce19154",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -132,7 +132,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -315,7 +315,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -356,13 +356,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -396,14 +396,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/examples/cargo_workspace/Cargo.Bazel.lock
+++ b/examples/cargo_workspace/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "9d2c19e3c75fa2b4bed4173bd1dc0e13ca85e54376e49001d38ed44f9b686832",
+  "checksum": "a274b1bb7119d5218cc5e97c6220f63eb86641aef56c0e1224fee8561b626335",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -78,7 +78,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -365,7 +365,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -412,7 +412,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -423,13 +423,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -463,14 +463,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -641,7 +641,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5b043ce2f27a861020daef2d67db6c7faeb61c8e1d10f3a84e69921e1c991b4f",
+  "checksum": "2e3ce382a6448ec4496dfa08b4898991b06442fb3d735b264f64ed47becbc793",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -112,7 +112,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -425,7 +425,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -824,7 +824,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -1025,13 +1025,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -1069,14 +1069,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1453,7 +1453,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -2429,7 +2429,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "d6d135635a4a207aeaf7ae4e6a8fcdda0d5beaaab20397e3cd7c47b5da7aecb3",
+  "checksum": "dfb0f862f35d99e6b0725026326cc52549aa0b1fa4ae39fd4546db454fb34a76",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -171,7 +171,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -430,7 +430,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -615,7 +615,7 @@
                 "target": "async_io"
               },
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               },
               {
@@ -954,7 +954,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -1579,7 +1579,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -1874,7 +1874,7 @@
               "target": "curl_sys"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -1960,7 +1960,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -2173,7 +2173,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -3163,7 +3163,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -3378,7 +3378,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -3700,7 +3700,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -4638,13 +4638,13 @@
       },
       "license": "MIT"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -4682,14 +4682,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4741,7 +4741,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -4815,7 +4815,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -5180,7 +5180,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -5295,7 +5295,7 @@
                 "target": "lazy_static"
               },
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               },
               {
@@ -5477,7 +5477,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -5606,7 +5606,7 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -5721,7 +5721,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -5929,7 +5929,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -6440,7 +6440,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -6875,7 +6875,7 @@
               "target": "http"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -7197,7 +7197,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -7248,7 +7248,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -7259,13 +7259,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.135": {
+    "serde 1.0.136": {
       "name": "serde",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.135/download",
-          "sha256": "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.136/download",
+          "sha256": "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
         }
       },
       "targets": [
@@ -7305,7 +7305,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "build_script_build"
             }
           ],
@@ -7315,13 +7315,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.135"
+        "version": "1.0.136"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7330,13 +7330,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.135": {
+    "serde_derive 1.0.136": {
       "name": "serde_derive",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.135/download",
-          "sha256": "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.136/download",
+          "sha256": "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
         }
       },
       "targets": [
@@ -7381,7 +7381,7 @@
               "target": "quote"
             },
             {
-              "id": "serde_derive 1.0.135",
+              "id": "serde_derive 1.0.136",
               "target": "build_script_build"
             },
             {
@@ -7392,7 +7392,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.135"
+        "version": "1.0.136"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -7453,7 +7453,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -7505,7 +7505,7 @@
               "target": "regex"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -7556,7 +7556,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -7611,7 +7611,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             },
             {
@@ -7663,7 +7663,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -7886,7 +7886,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -8082,7 +8082,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -8378,7 +8378,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               },
               {

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3743e9158ba35123bd411c1e66042b9b225c88f3a0aac0aba541df8c53be3b64",
+  "checksum": "e6e42078bac006636a7b069d9dc9cda9d3f3ac7db039a2f61df7e2045c62cbc7",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -226,7 +226,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -498,7 +498,7 @@
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.6",
+              "id": "tracing-subscriber 0.3.7",
               "target": "tracing_subscriber"
             }
           ],
@@ -1024,7 +1024,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -1566,13 +1566,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.113": {
+    "libc 0.2.114": {
       "name": "libc",
-      "version": "0.2.113",
+      "version": "0.2.114",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.113/download",
-          "sha256": "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.114/download",
+          "sha256": "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
         }
       },
       "targets": [
@@ -1610,14 +1610,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.113"
+        "version": "0.2.114"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1926,7 +1926,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -2090,7 +2090,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ]
@@ -2252,7 +2252,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -2656,13 +2656,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "serde 1.0.135": {
+    "serde 1.0.136": {
       "name": "serde",
-      "version": "1.0.135",
+      "version": "1.0.136",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.135/download",
-          "sha256": "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.136/download",
+          "sha256": "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
         }
       },
       "targets": [
@@ -2700,14 +2700,14 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.135"
+        "version": "1.0.136"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2769,7 +2769,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             },
             {
@@ -2829,7 +2829,7 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.135",
+              "id": "serde 1.0.136",
               "target": "serde"
             }
           ],
@@ -2907,7 +2907,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.113",
+              "id": "libc 0.2.114",
               "target": "libc"
             }
           ],
@@ -3012,7 +3012,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               }
             ],
@@ -3140,13 +3140,13 @@
       },
       "license": "Apache-2.0"
     },
-    "thread_local 1.1.3": {
+    "thread_local 1.1.4": {
       "name": "thread_local",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thread_local/1.1.3/download",
-          "sha256": "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+          "url": "https://crates.io/api/v1/crates/thread_local/1.1.4/download",
+          "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
         }
       },
       "targets": [
@@ -3175,7 +3175,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.1.3"
+        "version": "1.1.4"
       },
       "license": "Apache-2.0/MIT"
     },
@@ -3263,7 +3263,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.113",
+                "id": "libc 0.2.114",
                 "target": "libc"
               },
               {
@@ -3839,13 +3839,13 @@
       },
       "license": "MIT"
     },
-    "tracing-subscriber 0.3.6": {
+    "tracing-subscriber 0.3.7": {
       "name": "tracing-subscriber",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.6/download",
-          "sha256": "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.7/download",
+          "sha256": "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
         }
       },
       "targets": [
@@ -3892,7 +3892,7 @@
               "target": "smallvec"
             },
             {
-              "id": "thread_local 1.1.3",
+              "id": "thread_local 1.1.4",
               "target": "thread_local"
             },
             {
@@ -3907,7 +3907,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.6"
+        "version": "0.3.7"
       },
       "license": "MIT"
     },

--- a/tools/cargo_bazel/Cargo.toml
+++ b/tools/cargo_bazel/Cargo.toml
@@ -11,8 +11,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.51"
 cargo_metadata = "0.14.1"
-# https://gitlab.com/crates.rs/cargo_toml/-/merge_requests/9
-cargo_toml = { git = "https://gitlab.com/crates.rs/cargo_toml.git", rev = "78b84638c89dc699923802a9b414b01b69b3417e" }
+cargo_toml = "0.11.1"
 cargo-lock = "7.0.1"
 cargo-platform = "0.1.2"
 cfg-expr = "0.9.0"


### PR DESCRIPTION
Now that [cargo_toml 0.11.1](https://crates.io/crates/cargo_toml/0.11.1) is out.