### PR TITLE
Updated `rules_rust` and `cargo_toml` dependencies

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "067f853bd08c35a181857ab2c67a5ac98495d278f64fbc474e8c794c32b63197",
+  "checksum": "35731b79f5423c18626ae4579661a18c1101245293ae80e14a42db5c8942d672",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -170,7 +170,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -600,7 +600,7 @@
               "target": "cargo_toml"
             },
             {
-              "id": "cfg-expr 0.9.0",
+              "id": "cfg-expr 0.9.1",
               "target": "cfg_expr"
             },
             {
@@ -832,9 +832,12 @@
       "name": "cargo_toml",
       "version": "0.11.3",
       "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/cargo_toml/0.11.3/download",
-          "sha256": "31f61f8437a6b96dfb0be4aad6b222e01d5681b1ceacac7251501389e169e219"
+        "Git": {
+          "remote": "https://gitlab.com/UebelAndre/cargo_toml.git",
+          "commitish": {
+            "Rev": "bcb72088defc99192566a04f71e9569551386d5a"
+          },
+          "shallow_since": "1643746537 -0800"
         }
       },
       "targets": [
@@ -935,13 +938,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "cfg-expr 0.9.0": {
+    "cfg-expr 0.9.1": {
       "name": "cfg-expr",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/cfg-expr/0.9.0/download",
-          "sha256": "edae0b9625d1fce32f7d64b71784d9b1bf8469ec1a9c417e44aaf16a9cbd7571"
+          "url": "https://crates.io/api/v1/crates/cfg-expr/0.9.1/download",
+          "sha256": "3431df59f28accaf4cb4eed4a9acc66bea3f3c3753aa6cdc2f024174ef232af7"
         }
       },
       "targets": [
@@ -973,7 +976,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.9.0"
+        "version": "0.9.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -1041,7 +1044,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -1375,7 +1378,7 @@
           "selects": {
             "aarch64-apple-darwin": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -1990,7 +1993,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -2048,7 +2051,7 @@
               "target": "crc32fast"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -2292,7 +2295,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -2335,7 +2338,7 @@
               "target": "bitflags"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -2557,7 +2560,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -2980,7 +2983,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -3021,13 +3024,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -3065,14 +3068,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3109,7 +3112,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -3158,7 +3161,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -4525,7 +4528,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -5667,7 +5670,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               },
               {
@@ -5725,7 +5728,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -7218,7 +7221,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,8 +168,7 @@ dependencies = [
 [[package]]
 name = "cargo_toml"
 version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f61f8437a6b96dfb0be4aad6b222e01d5681b1ceacac7251501389e169e219"
+source = "git+https://gitlab.com/UebelAndre/cargo_toml.git?rev=bcb72088defc99192566a04f71e9569551386d5a#bcb72088defc99192566a04f71e9569551386d5a"
 dependencies = [
  "serde",
  "serde_derive",
@@ -187,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edae0b9625d1fce32f7d64b71784d9b1bf8469ec1a9c417e44aaf16a9cbd7571"
+checksum = "3431df59f28accaf4cb4eed4a9acc66bea3f3c3753aa6cdc2f024174ef232af7"
 dependencies = [
  "smallvec",
 ]
@@ -236,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.12"
+version = "3.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
+checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
 dependencies = [
  "atty",
  "bitflags",
@@ -601,9 +600,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.114"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0005d08a8f7b65fb8073cb697aa0b12b631ed251ce73d862ce50eeb52ce3b50"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libgit2-sys"

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -21,6 +21,9 @@ load("//:defs.bzl", "crate", "crates_repository")
 crates_repository(
     name = "crate_index",
     annotations = {
+        "cargo_toml": [crate.annotation(
+            shallow_since = "1643746537 -0800",
+        )],
         "chrono-tz": [crate.annotation(
             build_script_data_glob = ["**/tz/**"],
         )],

--- a/deps.bzl
+++ b/deps.bzl
@@ -8,11 +8,11 @@ def cargo_bazel_deps():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "1a919f80faf6a5e3ee1d0fccf84775c5f6f6ee062eb413dd9f7560b6b02008bb",
-        strip_prefix = "rules_rust-1cb3c446b263c16b373e259e988f00c5f1e3f175",
+        sha256 = "b5be39325f98bd0a26c8a3be88f67041371cf64887f287331eeabd03e1ec2277",
+        strip_prefix = "rules_rust-5776967a2a9986d52a34e2c3604ed662ed47e21f",
         urls = [
-            # `main` branch as of 2022-01-27
-            "https://github.com/bazelbuild/rules_rust/archive/1cb3c446b263c16b373e259e988f00c5f1e3f175.tar.gz",
+            # `main` branch as of 2022-02-01
+            "https://github.com/bazelbuild/rules_rust/archive/5776967a2a9986d52a34e2c3604ed662ed47e21f.tar.gz",
         ],
     )
 

--- a/examples/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "09572aca61f65b6386d7128713bce6fbf681a8520c724be649b70f72ea07989f",
+  "checksum": "16a7354959a1b46149ca2fc4cde1b7952f56de83f7c5759c9155878b44dac071",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -132,7 +132,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -315,7 +315,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -356,13 +356,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -396,14 +396,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [

--- a/examples/cargo_workspace/Cargo.Bazel.lock
+++ b/examples/cargo_workspace/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0f8eef099e2982b19d6c0baee8e15ffe0e2e2a0da0aafecbfa458d64830df13c",
+  "checksum": "a568542017702981d6ad8832f4ac306212f87f55a997c09f2c4977fd5ba2c1e3",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -78,7 +78,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -365,7 +365,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -412,7 +412,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -423,13 +423,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -463,14 +463,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -641,7 +641,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "5f9b33bd90551d34d35cfa36f00bed4fb9596177d2eace10f6743316753d5a9e",
+  "checksum": "0cbbeabbe7aeaad71469cb991d0dea6c3d3c13660da6f9635be54455428fcae5",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -112,7 +112,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -425,7 +425,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -824,7 +824,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -1025,13 +1025,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -1069,14 +1069,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1453,7 +1453,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -2429,7 +2429,7 @@
           "selects": {
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "e1d1ebb4572b0d901de84d3d2e405a94c0146c0acda61353b9e962cbf0472a0c",
+  "checksum": "200385f0e9957aa24cf7ae6f329b279bae9da511255a5b8463f97b3f0d3f1f75",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -430,7 +430,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -615,7 +615,7 @@
                 "target": "async_io"
               },
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               },
               {
@@ -771,7 +771,7 @@
                 "target": "futures_channel"
               },
               {
-                "id": "gloo-timers 0.2.2",
+                "id": "gloo-timers 0.2.3",
                 "target": "gloo_timers"
               },
               {
@@ -954,7 +954,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -1579,7 +1579,7 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -1874,7 +1874,7 @@
               "target": "curl_sys"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -1960,7 +1960,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -2173,7 +2173,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -3163,7 +3163,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -3174,13 +3174,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gloo-timers 0.2.2": {
+    "gloo-timers 0.2.3": {
       "name": "gloo-timers",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gloo-timers/0.2.2/download",
-          "sha256": "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
+          "url": "https://crates.io/api/v1/crates/gloo-timers/0.2.3/download",
+          "sha256": "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
         }
       },
       "targets": [
@@ -3222,16 +3222,12 @@
             {
               "id": "wasm-bindgen 0.2.79",
               "target": "wasm_bindgen"
-            },
-            {
-              "id": "web-sys 0.3.56",
-              "target": "web_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.2.2"
+        "version": "0.2.3"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -3295,7 +3291,7 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -3378,7 +3374,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -3716,7 +3712,7 @@
               "target": "similar"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -3827,7 +3823,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -3890,7 +3886,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -4638,13 +4634,13 @@
       },
       "license": "MIT"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -4682,14 +4678,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -4741,7 +4737,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -4815,7 +4811,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -4857,13 +4853,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "lock_api 0.4.5": {
+    "lock_api 0.4.6": {
       "name": "lock_api",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/lock_api/0.4.5/download",
-          "sha256": "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+          "url": "https://crates.io/api/v1/crates/lock_api/0.4.6/download",
+          "sha256": "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
         }
       },
       "targets": [
@@ -4892,7 +4888,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.5"
+        "version": "0.4.6"
       },
       "license": "Apache-2.0/MIT"
     },
@@ -5180,7 +5176,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -5295,15 +5291,15 @@
                 "target": "lazy_static"
               },
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               },
               {
-                "id": "security-framework 2.5.0",
+                "id": "security-framework 2.6.0",
                 "target": "security_framework"
               },
               {
-                "id": "security-framework-sys 2.5.0",
+                "id": "security-framework-sys 2.6.0",
                 "target": "security_framework_sys"
               },
               {
@@ -5477,7 +5473,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -5606,7 +5602,7 @@
               "target": "foreign_types"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -5721,7 +5717,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -5849,7 +5845,7 @@
               "target": "instant"
             },
             {
-              "id": "lock_api 0.4.5",
+              "id": "lock_api 0.4.6",
               "target": "lock_api"
             },
             {
@@ -5929,7 +5925,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -6440,7 +6436,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"fuchsia\", target_os = \"vxworks\"))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -6955,7 +6951,7 @@
                 "target": "pin_project_lite"
               },
               {
-                "id": "tokio 1.15.0",
+                "id": "tokio 1.16.1",
                 "target": "tokio"
               },
               {
@@ -7153,13 +7149,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "security-framework 2.5.0": {
+    "security-framework 2.6.0": {
       "name": "security-framework",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/security-framework/2.5.0/download",
-          "sha256": "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+          "url": "https://crates.io/api/v1/crates/security-framework/2.6.0/download",
+          "sha256": "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
         }
       },
       "targets": [
@@ -7197,28 +7193,28 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
-              "id": "security-framework-sys 2.5.0",
+              "id": "security-framework-sys 2.6.0",
               "target": "security_framework_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.6.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "security-framework-sys 2.5.0": {
+    "security-framework-sys 2.6.0": {
       "name": "security-framework-sys",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/security-framework-sys/2.5.0/download",
-          "sha256": "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+          "url": "https://crates.io/api/v1/crates/security-framework-sys/2.6.0/download",
+          "sha256": "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
         }
       },
       "targets": [
@@ -7248,14 +7244,14 @@
               "target": "core_foundation_sys"
             },
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.5.0"
+        "version": "2.6.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -7611,7 +7607,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             },
             {
@@ -7663,7 +7659,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -7886,7 +7882,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -8082,7 +8078,7 @@
           "selects": {
             "cfg(any(unix, target_os = \"wasi\"))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -8303,13 +8299,13 @@
       },
       "license": "MIT OR Apache-2.0 OR Zlib"
     },
-    "tokio 1.15.0": {
+    "tokio 1.16.1": {
       "name": "tokio",
-      "version": "1.15.0",
+      "version": "1.16.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.15.0/download",
-          "sha256": "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+          "url": "https://crates.io/api/v1/crates/tokio/1.16.1/download",
+          "sha256": "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
         }
       },
       "targets": [
@@ -8378,7 +8374,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               },
               {
@@ -8404,7 +8400,7 @@
           ],
           "selects": {}
         },
-        "version": "1.15.0"
+        "version": "1.16.1"
       },
       "license": "MIT"
     },
@@ -8487,7 +8483,7 @@
               "target": "native_tls"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             }
           ],
@@ -8550,7 +8546,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             }
           ],

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f6ae11db98ee2419a0568aa5bd8b66f3317a1b3fc4ec3380e6db85707d44c37a",
+  "checksum": "f1f3fb003c2bc622425be211aadbf873e3e309b60c6837988dec265214b17392",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -140,13 +140,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "axum 0.4.4": {
+    "axum 0.4.5": {
       "name": "axum",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/axum/0.4.4/download",
-          "sha256": "310a147401c66e79fc78636e4db63ac68cd6acb9ece056de806ea173a15bce32"
+          "url": "https://crates.io/api/v1/crates/axum/0.4.5/download",
+          "sha256": "1dbbc81d15ddf33148615b778836b525dbae4e0731710294b2c484e80c4858f7"
         }
       },
       "targets": [
@@ -206,7 +206,7 @@
               "target": "hyper"
             },
             {
-              "id": "matchit 0.4.4",
+              "id": "matchit 0.4.6",
               "target": "matchit"
             },
             {
@@ -242,7 +242,7 @@
               "target": "sync_wrapper"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -278,7 +278,7 @@
           ],
           "selects": {}
         },
-        "version": "0.4.4"
+        "version": "0.4.5"
       },
       "license": "MIT"
     },
@@ -466,7 +466,7 @@
         "deps": {
           "common": [
             {
-              "id": "axum 0.4.4",
+              "id": "axum 0.4.5",
               "target": "axum"
             },
             {
@@ -482,7 +482,7 @@
               "target": "serde_json"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -941,7 +941,7 @@
               "target": "slab"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -1024,7 +1024,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -1338,7 +1338,7 @@
               "target": "socket2"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {
@@ -1566,13 +1566,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "libc 0.2.115": {
+    "libc 0.2.116": {
       "name": "libc",
-      "version": "0.2.115",
+      "version": "0.2.116",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/libc/0.2.115/download",
-          "sha256": "0a8d982fa7a96a000f6ec4cfe966de9703eccde29750df2bb8949da91b0e818d"
+          "url": "https://crates.io/api/v1/crates/libc/0.2.116/download",
+          "sha256": "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
         }
       },
       "targets": [
@@ -1610,14 +1610,14 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "0.2.115"
+        "version": "0.2.116"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1626,13 +1626,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "lock_api 0.4.5": {
+    "lock_api 0.4.6": {
       "name": "lock_api",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/lock_api/0.4.5/download",
-          "sha256": "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+          "url": "https://crates.io/api/v1/crates/lock_api/0.4.6/download",
+          "sha256": "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
         }
       },
       "targets": [
@@ -1661,7 +1661,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.5"
+        "version": "0.4.6"
       },
       "license": "Apache-2.0/MIT"
     },
@@ -1758,13 +1758,13 @@
       },
       "license": "MIT"
     },
-    "matchit 0.4.4": {
+    "matchit 0.4.6": {
       "name": "matchit",
-      "version": "0.4.4",
+      "version": "0.4.6",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/matchit/0.4.4/download",
-          "sha256": "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
+          "url": "https://crates.io/api/v1/crates/matchit/0.4.6/download",
+          "sha256": "9376a4f0340565ad675d11fc1419227faf5f60cd7ac9cb2e7185a471f30af833"
         }
       },
       "targets": [
@@ -1787,7 +1787,7 @@
           "default"
         ],
         "edition": "2018",
-        "version": "0.4.4"
+        "version": "0.4.6"
       },
       "license": "MIT"
     },
@@ -1926,7 +1926,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -2090,7 +2090,7 @@
             ],
             "cfg(not(windows))": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ]
@@ -2172,7 +2172,7 @@
               "target": "instant"
             },
             {
-              "id": "lock_api 0.4.5",
+              "id": "lock_api 0.4.6",
               "target": "lock_api"
             },
             {
@@ -2252,7 +2252,7 @@
             ],
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -2907,7 +2907,7 @@
         "deps": {
           "common": [
             {
-              "id": "libc 0.2.115",
+              "id": "libc 0.2.116",
               "target": "libc"
             }
           ],
@@ -3012,7 +3012,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               }
             ],
@@ -3179,13 +3179,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "tokio 1.15.0": {
+    "tokio 1.16.1": {
       "name": "tokio",
-      "version": "1.15.0",
+      "version": "1.16.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tokio/1.15.0/download",
-          "sha256": "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+          "url": "https://crates.io/api/v1/crates/tokio/1.16.1/download",
+          "sha256": "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
         }
       },
       "targets": [
@@ -3263,7 +3263,7 @@
           "selects": {
             "cfg(unix)": [
               {
-                "id": "libc 0.2.115",
+                "id": "libc 0.2.116",
                 "target": "libc"
               },
               {
@@ -3289,7 +3289,7 @@
           ],
           "selects": {}
         },
-        "version": "1.15.0"
+        "version": "1.16.1"
       },
       "license": "MIT"
     },
@@ -3392,7 +3392,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             }
           ],
@@ -3458,7 +3458,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tokio 1.15.0",
+              "id": "tokio 1.16.1",
               "target": "tokio"
             },
             {

--- a/tools/cargo_bazel/Cargo.toml
+++ b/tools/cargo_bazel/Cargo.toml
@@ -11,7 +11,8 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.51"
 cargo_metadata = "0.14.1"
-cargo_toml = "0.11.3"
+# https://gitlab.com/crates.rs/cargo_toml/-/merge_requests/10
+cargo_toml = { git = "https://gitlab.com/UebelAndre/cargo_toml.git", rev = "bcb72088defc99192566a04f71e9569551386d5a" }
 cargo-lock = "7.0.1"
 cargo-platform = "0.1.2"
 cfg-expr = "0.9.0"


### PR DESCRIPTION
The update to `rules_rust` is to pick up: https://github.com/bazelbuild/rules_rust/pull/1118

The update to `cargo_toml` is to pick up: https://gitlab.com/crates.rs/cargo_toml/-/merge_requests/10