### PR TITLE
`compile_data` for generated targets now include the entire package.

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "35731b79f5423c18626ae4579661a18c1101245293ae80e14a42db5c8942d672",
+  "checksum": "c79ebb3d14a30b43805aba392dc9d7fb795791ea1c051076e9d1562144c5bb69",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "adler",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.2"
       },
@@ -56,6 +59,9 @@
       ],
       "library_target_name": "aho_corasick",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -111,6 +117,9 @@
       ],
       "library_target_name": "anyhow",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -159,6 +168,9 @@
       ],
       "library_target_name": "atty",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -212,6 +224,9 @@
       ],
       "library_target_name": "autocfg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.1"
       },
@@ -242,6 +257,9 @@
       ],
       "library_target_name": "bitflags",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -275,6 +293,9 @@
       ],
       "library_target_name": "block_buffer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -314,6 +335,9 @@
       ],
       "library_target_name": "block_buffer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -365,6 +389,9 @@
       ],
       "library_target_name": "block_padding",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -404,6 +431,9 @@
       ],
       "library_target_name": "bstr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -446,6 +476,9 @@
       ],
       "library_target_name": "byte_tools",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.3.1"
       },
@@ -476,6 +509,9 @@
       ],
       "library_target_name": "byteorder",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.4.3"
       },
@@ -518,6 +554,9 @@
       ],
       "library_target_name": "camino",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "serde",
           "serde1"
@@ -577,6 +616,9 @@
       ],
       "library_target_name": "cargo_bazel",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -705,6 +747,9 @@
       ],
       "library_target_name": "cargo_lock",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -756,6 +801,9 @@
       ],
       "library_target_name": "cargo_platform",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -795,6 +843,9 @@
       ],
       "library_target_name": "cargo_metadata",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -856,6 +907,9 @@
       ],
       "library_target_name": "cargo_toml",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -920,6 +974,9 @@
       ],
       "library_target_name": "cc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "jobserver",
           "parallel"
@@ -963,6 +1020,9 @@
       ],
       "library_target_name": "cfg_expr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1005,6 +1065,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -1035,6 +1098,9 @@
       ],
       "library_target_name": "chrono",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "clock",
           "libc",
@@ -1107,6 +1173,9 @@
       ],
       "library_target_name": "chrono_tz",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1133,8 +1202,7 @@
       },
       "build_script_attrs": {
         "data_glob": [
-          "**",
-          "**/tz/**"
+          "**"
         ],
         "deps": {
           "common": [
@@ -1173,6 +1241,9 @@
       ],
       "library_target_name": "chrono_tz_build",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1221,7 +1292,7 @@
       "library_target_name": "clap",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.md"
+          "**"
         ],
         "crate_features": [
           "atty",
@@ -1313,7 +1384,7 @@
       "library_target_name": "clap_derive",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.md"
+          "**"
         ],
         "crate_features": [
           "default"
@@ -1373,6 +1444,9 @@
       ],
       "library_target_name": "cpufeatures",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -1414,6 +1488,9 @@
       ],
       "library_target_name": "crates_index",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1502,6 +1579,9 @@
       ],
       "library_target_name": "crc32fast",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1549,6 +1629,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1600,6 +1683,9 @@
       ],
       "library_target_name": "crossbeam_utils",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lazy_static",
@@ -1627,8 +1713,7 @@
       },
       "build_script_attrs": {
         "data_glob": [
-          "**",
-          "**/*.rs"
+          "**"
         ]
       },
       "license": "MIT OR Apache-2.0"
@@ -1658,6 +1743,9 @@
       ],
       "library_target_name": "crypto_common",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -1701,8 +1789,7 @@
       "library_target_name": "deunicode",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.bin",
-          "**/*.txt"
+          "**"
         ],
         "edition": "2015",
         "version": "0.4.3"
@@ -1734,6 +1821,9 @@
       ],
       "library_target_name": "digest",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "block-buffer",
@@ -1788,6 +1878,9 @@
       ],
       "library_target_name": "digest",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1822,6 +1915,9 @@
       ],
       "library_target_name": "direct_cargo_bazel_deps",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.0.1"
       },
@@ -1847,6 +1943,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1906,6 +2005,9 @@
       ],
       "library_target_name": "fake_simd",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.2"
       },
@@ -1936,6 +2038,9 @@
       ],
       "library_target_name": "fastrand",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -1977,6 +2082,9 @@
       ],
       "library_target_name": "filetime",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2035,6 +2143,9 @@
       ],
       "library_target_name": "flate2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "miniz_oxide",
@@ -2091,6 +2202,9 @@
       ],
       "library_target_name": "fnv",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2125,6 +2239,9 @@
       ],
       "library_target_name": "form_urlencoded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2168,6 +2285,9 @@
       ],
       "library_target_name": "generic_array",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2219,6 +2339,9 @@
       ],
       "library_target_name": "generic_array",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2276,6 +2399,9 @@
       ],
       "library_target_name": "getrandom",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -2331,6 +2457,9 @@
       ],
       "library_target_name": "git2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2386,6 +2515,9 @@
       ],
       "library_target_name": "globset",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2441,6 +2573,9 @@
       ],
       "library_target_name": "globwalk",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2488,6 +2623,9 @@
       ],
       "library_target_name": "hashbrown",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "raw"
         ],
@@ -2521,6 +2659,9 @@
       ],
       "library_target_name": "heck",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2554,6 +2695,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2596,6 +2740,9 @@
       ],
       "library_target_name": "hex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2641,6 +2788,9 @@
       ],
       "library_target_name": "home",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -2682,6 +2832,9 @@
       ],
       "library_target_name": "humansize",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.1.1"
       },
@@ -2712,6 +2865,9 @@
       ],
       "library_target_name": "idna",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2759,6 +2915,9 @@
       ],
       "library_target_name": "ignore",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2849,6 +3008,9 @@
       ],
       "library_target_name": "indexmap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -2909,6 +3071,9 @@
       ],
       "library_target_name": "instant",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2948,6 +3113,9 @@
       ],
       "library_target_name": "itoa",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.1"
       },
@@ -2978,6 +3146,9 @@
       ],
       "library_target_name": "jobserver",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -3019,6 +3190,9 @@
       ],
       "library_target_name": "lazy_static",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.4.0"
       },
@@ -3061,6 +3235,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -3109,6 +3286,9 @@
       ],
       "library_target_name": "libgit2_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3155,6 +3335,9 @@
       ],
       "library_target_name": "libz_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "libc"
         ],
@@ -3212,6 +3395,9 @@
       ],
       "library_target_name": "log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3260,6 +3446,9 @@
       ],
       "library_target_name": "maplit",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.2"
       },
@@ -3290,6 +3479,9 @@
       ],
       "library_target_name": "matches",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.9"
       },
@@ -3332,6 +3524,9 @@
       ],
       "library_target_name": "memchr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -3392,6 +3587,9 @@
       ],
       "library_target_name": "miniz_oxide",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3461,6 +3659,9 @@
       ],
       "library_target_name": "num_integer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3530,6 +3731,9 @@
       ],
       "library_target_name": "num_traits",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3583,6 +3787,9 @@
       ],
       "library_target_name": "once_cell",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -3619,6 +3826,9 @@
       ],
       "library_target_name": "opaque_debug",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.3"
       },
@@ -3649,6 +3859,9 @@
       ],
       "library_target_name": "os_str_bytes",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "memchr",
@@ -3693,6 +3906,9 @@
       ],
       "library_target_name": "parse_zoneinfo",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3732,6 +3948,9 @@
       ],
       "library_target_name": "pathdiff",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.2.1"
       },
@@ -3762,6 +3981,9 @@
       ],
       "library_target_name": "percent_encoding",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "2.1.0"
       },
@@ -3792,6 +4014,9 @@
       ],
       "library_target_name": "pest",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3831,6 +4056,9 @@
       ],
       "library_target_name": "pest_derive",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3874,6 +4102,9 @@
       ],
       "library_target_name": "pest_generator",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3929,6 +4160,9 @@
       ],
       "library_target_name": "pest_meta",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3972,6 +4206,9 @@
       ],
       "library_target_name": "phf",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "uncased"
         ],
@@ -4014,6 +4251,9 @@
       ],
       "library_target_name": "phf_codegen",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4069,6 +4309,9 @@
       ],
       "library_target_name": "phf_generator",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4112,6 +4355,9 @@
       ],
       "library_target_name": "phf_shared",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std",
@@ -4160,6 +4406,9 @@
       ],
       "library_target_name": "pkg_config",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.3.24"
       },
@@ -4190,6 +4439,9 @@
       ],
       "library_target_name": "ppv_lite86",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "simd",
           "std"
@@ -4236,6 +4488,9 @@
       ],
       "library_target_name": "proc_macro_error",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "syn",
@@ -4327,6 +4582,9 @@
       ],
       "library_target_name": "proc_macro_error_attr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4400,6 +4658,9 @@
       ],
       "library_target_name": "proc_macro2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -4452,6 +4713,9 @@
       ],
       "library_target_name": "quote",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -4495,6 +4759,9 @@
       ],
       "library_target_name": "rand",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -4564,6 +4831,9 @@
       ],
       "library_target_name": "rand_chacha",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -4610,6 +4880,9 @@
       ],
       "library_target_name": "rand_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "getrandom",
@@ -4654,6 +4927,9 @@
       ],
       "library_target_name": "rand_hc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4693,6 +4969,9 @@
       ],
       "library_target_name": "syscall",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4732,6 +5011,9 @@
       ],
       "library_target_name": "regex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "aho-corasick",
           "default",
@@ -4798,6 +5080,9 @@
       ],
       "library_target_name": "regex_syntax",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "unicode",
@@ -4839,6 +5124,9 @@
       ],
       "library_target_name": "remove_dir_all",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -4880,6 +5168,9 @@
       ],
       "library_target_name": "ryu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.9"
       },
@@ -4910,6 +5201,9 @@
       ],
       "library_target_name": "same_file",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -4963,6 +5257,9 @@
       ],
       "library_target_name": "semver",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "serde",
@@ -5028,6 +5325,9 @@
       ],
       "library_target_name": "serde",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "derive",
@@ -5100,6 +5400,9 @@
       ],
       "library_target_name": "serde_derive",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -5171,6 +5474,9 @@
       ],
       "library_target_name": "serde_json",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std",
@@ -5232,6 +5538,9 @@
       ],
       "library_target_name": "sha1",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5283,6 +5592,9 @@
       ],
       "library_target_name": "sha2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -5337,6 +5649,9 @@
       ],
       "library_target_name": "siphasher",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -5371,6 +5686,9 @@
       ],
       "library_target_name": "slug",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5410,6 +5728,9 @@
       ],
       "library_target_name": "smallvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.8.0"
       },
@@ -5440,6 +5761,9 @@
       ],
       "library_target_name": "smartstring",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "serde",
@@ -5488,6 +5812,9 @@
       ],
       "library_target_name": "smawk",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -5518,6 +5845,9 @@
       ],
       "library_target_name": "static_assertions",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.1.0"
       },
@@ -5548,6 +5878,9 @@
       ],
       "library_target_name": "strsim",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.10.0"
       },
@@ -5590,6 +5923,9 @@
       ],
       "library_target_name": "syn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "clone-impls",
           "default",
@@ -5656,6 +5992,9 @@
       ],
       "library_target_name": "tar",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "xattr"
@@ -5710,6 +6049,9 @@
       ],
       "library_target_name": "tempfile",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5777,7 +6119,7 @@
       "library_target_name": "tera",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.pest"
+          "**"
         ],
         "crate_features": [
           "builtins",
@@ -5885,6 +6227,9 @@
       ],
       "library_target_name": "termcolor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -5926,6 +6271,9 @@
       ],
       "library_target_name": "textwrap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "smawk",
@@ -5979,6 +6327,9 @@
       ],
       "library_target_name": "thread_local",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6018,6 +6369,9 @@
       ],
       "library_target_name": "tinyvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -6062,6 +6416,9 @@
       ],
       "library_target_name": "tinyvec_macros",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.0"
       },
@@ -6092,6 +6449,9 @@
       ],
       "library_target_name": "toml",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -6146,6 +6506,9 @@
       ],
       "library_target_name": "typenum",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6190,6 +6553,9 @@
       ],
       "library_target_name": "ucd_trie",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6236,6 +6602,9 @@
       ],
       "library_target_name": "uncased",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6289,6 +6658,9 @@
       ],
       "library_target_name": "unic_char_property",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6328,6 +6700,9 @@
       ],
       "library_target_name": "unic_char_range",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -6361,6 +6736,9 @@
       ],
       "library_target_name": "unic_common",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -6394,6 +6772,9 @@
       ],
       "library_target_name": "unic_segment",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6434,7 +6815,7 @@
       "library_target_name": "unic_ucd_segment",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.rsv"
+          "**"
         ],
         "deps": {
           "common": [
@@ -6484,7 +6865,7 @@
       "library_target_name": "unic_ucd_version",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.rsv"
+          "**"
         ],
         "deps": {
           "common": [
@@ -6525,6 +6906,9 @@
       ],
       "library_target_name": "unicode_bidi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6571,6 +6955,9 @@
       ],
       "library_target_name": "unicode_linebreak",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6585,9 +6972,7 @@
       },
       "build_script_attrs": {
         "data_glob": [
-          "**",
-          "**/*.rs",
-          "**/*.txt"
+          "**"
         ],
         "deps": {
           "common": [
@@ -6626,6 +7011,9 @@
       ],
       "library_target_name": "unicode_normalization",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6669,6 +7057,9 @@
       ],
       "library_target_name": "unicode_width",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -6702,6 +7093,9 @@
       ],
       "library_target_name": "unicode_xid",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -6735,6 +7129,9 @@
       ],
       "library_target_name": "url",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6781,6 +7178,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6832,6 +7232,9 @@
       ],
       "library_target_name": "vcpkg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.15"
       },
@@ -6862,6 +7265,9 @@
       ],
       "library_target_name": "version_check",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.9.4"
       },
@@ -6892,6 +7298,9 @@
       ],
       "library_target_name": "walkdir",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6942,6 +7351,9 @@
       ],
       "library_target_name": "wasi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6988,6 +7400,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "consoleapi",
           "errhandlingapi",
@@ -7073,6 +7488,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7117,6 +7535,9 @@
       ],
       "library_target_name": "winapi_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -7170,6 +7591,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7214,6 +7638,9 @@
       ],
       "library_target_name": "xattr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "unsupported"

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -24,24 +24,6 @@ crates_repository(
         "cargo_toml": [crate.annotation(
             shallow_since = "1643746537 -0800",
         )],
-        "chrono-tz": [crate.annotation(
-            build_script_data_glob = ["**/tz/**"],
-        )],
-        "clap": [crate.annotation(
-            compile_data_glob = ["**/*.md"],
-        )],
-        "clap_derive": [crate.annotation(
-            compile_data_glob = ["**/*.md"],
-        )],
-        "crossbeam-utils": [crate.annotation(
-            build_script_data_glob = ["**/*.rs"],
-        )],
-        "deunicode": [crate.annotation(
-            compile_data_glob = [
-                "**/*.txt",
-                "**/*.bin",
-            ],
-        )],
         "libgit2-sys": [crate.annotation(
             gen_build_script = False,
             deps = ["@libgit2"],
@@ -49,21 +31,6 @@ crates_repository(
         "libz-sys": [crate.annotation(
             gen_build_script = False,
             deps = ["@zlib"],
-        )],
-        "tera": [crate.annotation(
-            compile_data_glob = ["**/*.pest"],
-        )],
-        "unic-ucd-segment": [crate.annotation(
-            compile_data_glob = ["**/*.rsv"],
-        )],
-        "unic-ucd-version": [crate.annotation(
-            compile_data_glob = ["**/*.rsv"],
-        )],
-        "unicode-linebreak": [crate.annotation(
-            build_script_data_glob = [
-                "**/*.rs",
-                "**/*.txt",
-            ],
         )],
     },
     generator = "@cargo_bazel_bootstrap//:cargo-bazel",

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -108,12 +108,6 @@ cargo_workspace_crate_repositories()
 
 crates_repository(
     name = "crate_index_extra_members",
-    annotations = {
-        "image": [crate.annotation(
-            compile_data_glob = ["**/*.md"],
-            version = "*",
-        )],
-    },
     extra_workspace_members = {
         "texture-synthesis-cli": crate.workspace_member(
             sha256 = "a7dbdf13f5e6f214750fce1073279b71ce3076157a8d337c9b0f0e14334e2aec",
@@ -141,9 +135,6 @@ crates_repository(
     # when running the `libnghttp2-sys` build script.
     name = "m_pkgs",
     annotations = {
-        "basic-cookies": [crate.annotation(
-            build_script_data_glob = ["**/*.lalrpop"],
-        )],
         "curl-sys": [crate.annotation(
             gen_build_script = False,
             deps = [
@@ -157,9 +148,6 @@ crates_repository(
         "libnghttp2-sys": [crate.annotation(
             build_script_data_glob = ["nghttp2/**"],
             data_glob = ["nghttp2/**"],
-        )],
-        "libz-sys": [crate.annotation(
-            build_script_data_glob = ["src/**"],
         )],
         "openssl-sys": [crate.annotation(
             build_script_data = [

--- a/examples/cargo_aliases/Cargo.Bazel.lock
+++ b/examples/cargo_aliases/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "16a7354959a1b46149ca2fc4cde1b7952f56de83f7c5759c9155878b44dac071",
+  "checksum": "70b06804edc48edb95630f1ceb4899e277df5d22932e8cf6185b3c6697ac8a43",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "aho_corasick",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -64,6 +67,9 @@
       ],
       "library_target_name": "aliases",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -121,6 +127,9 @@
       ],
       "library_target_name": "atty",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -174,6 +183,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -204,6 +216,9 @@
       ],
       "library_target_name": "ctor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -247,6 +262,9 @@
       ],
       "library_target_name": "env_logger",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "atty",
           "default",
@@ -309,6 +327,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -351,6 +372,9 @@
       ],
       "library_target_name": "humantime",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "2.1.0"
       },
@@ -393,6 +417,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -437,6 +464,9 @@
       ],
       "library_target_name": "log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "use_std"
@@ -492,6 +522,9 @@
       ],
       "library_target_name": "log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -555,6 +588,9 @@
       ],
       "library_target_name": "memchr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -615,6 +651,9 @@
       ],
       "library_target_name": "proc_macro2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "proc-macro"
         ],
@@ -666,6 +705,9 @@
       ],
       "library_target_name": "quote",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -709,6 +751,9 @@
       ],
       "library_target_name": "regex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "aho-corasick",
           "memchr",
@@ -766,6 +811,9 @@
       ],
       "library_target_name": "regex_syntax",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.6.25"
       },
@@ -808,6 +856,9 @@
       ],
       "library_target_name": "syn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "full",
           "parsing",
@@ -871,6 +922,9 @@
       ],
       "library_target_name": "termcolor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -912,6 +966,9 @@
       ],
       "library_target_name": "unicode_xid",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -957,6 +1014,9 @@
       ],
       "library_target_name": "value_bag",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1020,6 +1080,9 @@
       ],
       "library_target_name": "version_check",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.9.4"
       },
@@ -1062,6 +1125,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "consoleapi",
           "errhandlingapi",
@@ -1144,6 +1210,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1188,6 +1257,9 @@
       ],
       "library_target_name": "winapi_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -1241,6 +1313,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {

--- a/examples/cargo_workspace/Cargo.Bazel.lock
+++ b/examples/cargo_workspace/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "a568542017702981d6ad8832f4ac306212f87f55a997c09f2c4977fd5ba2c1e3",
+  "checksum": "03a66104f0c8deba30dca1b8160eb12cd85005881fd368f53f5b9f4f4adecf45",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "ansi_term",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -67,6 +70,9 @@
       ],
       "library_target_name": "atty",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -120,6 +126,9 @@
       ],
       "library_target_name": "bitflags",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -153,6 +162,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -183,6 +195,9 @@
       ],
       "library_target_name": "clap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "ansi_term",
           "atty",
@@ -253,6 +268,9 @@
       ],
       "library_target_name": "direct_cargo_bazel_deps",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.0.1"
       },
@@ -283,6 +301,9 @@
       ],
       "library_target_name": "ferris_says",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -342,6 +363,9 @@
       ],
       "library_target_name": "getrandom",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -406,6 +430,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -460,6 +487,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -499,6 +529,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -538,6 +571,9 @@
       ],
       "library_target_name": "ppv_lite86",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "simd",
           "std"
@@ -567,6 +603,9 @@
       ],
       "library_target_name": "printer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -606,6 +645,9 @@
       ],
       "library_target_name": "rand",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -677,6 +719,9 @@
       ],
       "library_target_name": "rand_chacha",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -723,6 +768,9 @@
       ],
       "library_target_name": "rand_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "getrandom",
@@ -767,6 +815,9 @@
       ],
       "library_target_name": "rand_hc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -801,6 +852,9 @@
       ],
       "library_target_name": "rng",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -840,6 +894,9 @@
       ],
       "library_target_name": "smallvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -874,6 +931,9 @@
       ],
       "library_target_name": "smawk",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -904,6 +964,9 @@
       ],
       "library_target_name": "strsim",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.8.0"
       },
@@ -934,6 +997,9 @@
       ],
       "library_target_name": "textwrap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -973,6 +1039,9 @@
       ],
       "library_target_name": "textwrap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "smawk",
@@ -1021,6 +1090,9 @@
       ],
       "library_target_name": "unicode_width",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1054,6 +1126,9 @@
       ],
       "library_target_name": "vec_map",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.8.2"
       },
@@ -1084,6 +1159,9 @@
       ],
       "library_target_name": "wasi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1130,6 +1208,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "consoleapi",
           "errhandlingapi",
@@ -1209,6 +1290,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1265,6 +1349,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "0cbbeabbe7aeaad71469cb991d0dea6c3d3c13660da6f9635be54455428fcae5",
+  "checksum": "e4ce5a1e7b534db0ab23cab71e88230f1ac108dacd3755560390f2a41093dd8f",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "adler32",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -60,6 +63,9 @@
       ],
       "library_target_name": "ansi_term",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -101,6 +107,9 @@
       ],
       "library_target_name": "atty",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -154,6 +163,9 @@
       ],
       "library_target_name": "autocfg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.1"
       },
@@ -184,6 +196,9 @@
       ],
       "library_target_name": "bitflags",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -217,6 +232,9 @@
       ],
       "library_target_name": "bytemuck",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.7.3"
       },
@@ -247,6 +265,9 @@
       ],
       "library_target_name": "byteorder",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -281,6 +302,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -311,6 +335,9 @@
       ],
       "library_target_name": "clap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "ansi_term",
           "atty",
@@ -386,6 +413,9 @@
       ],
       "library_target_name": "color_quant",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.1.0"
       },
@@ -416,6 +446,9 @@
       ],
       "library_target_name": "console",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "ansi-parsing",
           "default",
@@ -500,6 +533,9 @@
       ],
       "library_target_name": "crc32fast",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -564,6 +600,9 @@
       ],
       "library_target_name": "crossbeam_utils",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lazy_static",
@@ -621,6 +660,9 @@
       ],
       "library_target_name": "deflate",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -664,6 +706,9 @@
       ],
       "library_target_name": "encode_unicode",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -693,6 +738,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -732,6 +780,9 @@
       ],
       "library_target_name": "ferris_says",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -779,6 +830,9 @@
       ],
       "library_target_name": "heck",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -818,6 +872,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -861,7 +918,7 @@
       "library_target_name": "image",
       "common_attrs": {
         "compile_data_glob": [
-          "**/*.md"
+          "**"
         ],
         "crate_features": [
           "bmp",
@@ -936,6 +993,9 @@
       ],
       "library_target_name": "indicatif",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -990,6 +1050,9 @@
       ],
       "library_target_name": "jpeg_decoder",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.22"
       },
@@ -1020,6 +1083,9 @@
       ],
       "library_target_name": "lazy_static",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.4.0"
       },
@@ -1062,6 +1128,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1110,6 +1179,9 @@
       ],
       "library_target_name": "miniz_oxide",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1161,6 +1233,9 @@
       ],
       "library_target_name": "num_integer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "i128",
           "std"
@@ -1234,6 +1309,9 @@
       ],
       "library_target_name": "num_iter",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1311,6 +1389,9 @@
       ],
       "library_target_name": "num_rational",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1384,6 +1465,9 @@
       ],
       "library_target_name": "num_traits",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "i128",
@@ -1442,6 +1526,9 @@
       ],
       "library_target_name": "num_cpus",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -1489,6 +1576,9 @@
       ],
       "library_target_name": "number_prefix",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1523,6 +1613,9 @@
       ],
       "library_target_name": "once_cell",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -1559,6 +1652,9 @@
       ],
       "library_target_name": "pdqselect",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2021",
         "version": "0.1.1"
       },
@@ -1589,6 +1685,9 @@
       ],
       "library_target_name": "png",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "deflate",
@@ -1657,6 +1756,9 @@
       ],
       "library_target_name": "proc_macro_error",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "syn",
@@ -1748,6 +1850,9 @@
       ],
       "library_target_name": "proc_macro_error_attr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1821,6 +1926,9 @@
       ],
       "library_target_name": "proc_macro2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -1873,6 +1981,9 @@
       ],
       "library_target_name": "quote",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -1916,6 +2027,9 @@
       ],
       "library_target_name": "rand",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1955,6 +2069,9 @@
       ],
       "library_target_name": "rand_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.6.3"
       },
@@ -1985,6 +2102,9 @@
       ],
       "library_target_name": "rand_pcg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2024,6 +2144,9 @@
       ],
       "library_target_name": "regex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -2066,6 +2189,9 @@
       ],
       "library_target_name": "regex_syntax",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.6.25"
       },
@@ -2096,6 +2222,9 @@
       ],
       "library_target_name": "rstar",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2142,6 +2271,9 @@
       ],
       "library_target_name": "smallvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2176,6 +2308,9 @@
       ],
       "library_target_name": "smawk",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -2206,6 +2341,9 @@
       ],
       "library_target_name": "strsim",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.8.0"
       },
@@ -2236,6 +2374,9 @@
       ],
       "library_target_name": "structopt",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2291,6 +2432,9 @@
       ],
       "library_target_name": "structopt_derive",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2358,6 +2502,9 @@
       ],
       "library_target_name": "syn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "clone-impls",
           "default",
@@ -2424,6 +2571,9 @@
       ],
       "library_target_name": "terminal_size",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -2471,6 +2621,9 @@
       ],
       "library_target_name": "texture_synthesis",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2533,6 +2686,9 @@
       ],
       "library_target_name": null,
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2590,6 +2746,9 @@
       ],
       "library_target_name": "textwrap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2629,6 +2788,9 @@
       ],
       "library_target_name": "textwrap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "smawk",
@@ -2677,6 +2839,9 @@
       ],
       "library_target_name": "unicode_segmentation",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.8.0"
       },
@@ -2707,6 +2872,9 @@
       ],
       "library_target_name": "unicode_width",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2740,6 +2908,9 @@
       ],
       "library_target_name": "unicode_xid",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2773,6 +2944,9 @@
       ],
       "library_target_name": "vec_map",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.8.2"
       },
@@ -2803,6 +2977,9 @@
       ],
       "library_target_name": "version_check",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.9.4"
       },
@@ -2845,6 +3022,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "consoleapi",
           "errhandlingapi",
@@ -2927,6 +3107,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2983,6 +3166,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "200385f0e9957aa24cf7ae6f329b279bae9da511255a5b8463f97b3f0d3f1f75",
+  "checksum": "df36f594f057e5974ef36651e114a211b3af624df743c071d3949358e8748320",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "aho_corasick",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -81,6 +84,9 @@
       ],
       "library_target_name": "anyhow",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -129,6 +135,9 @@
       ],
       "library_target_name": "ascii_canvas",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -168,6 +177,9 @@
       ],
       "library_target_name": "assert_json_diff",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -211,6 +223,9 @@
       ],
       "library_target_name": "async_channel",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -258,6 +273,9 @@
       ],
       "library_target_name": "async_executor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -317,6 +335,9 @@
       ],
       "library_target_name": "async_global_executor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "async-io",
           "default"
@@ -388,6 +409,9 @@
       ],
       "library_target_name": "async_io",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -472,6 +496,9 @@
       ],
       "library_target_name": "async_lock",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -511,6 +538,9 @@
       ],
       "library_target_name": "async_mutex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -550,6 +580,9 @@
       ],
       "library_target_name": "async_object_pool",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -589,6 +622,9 @@
       ],
       "library_target_name": "async_process",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -665,6 +701,9 @@
       ],
       "library_target_name": "async_std",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "async-channel",
@@ -811,6 +850,9 @@
       ],
       "library_target_name": "async_task",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -857,6 +899,9 @@
       ],
       "library_target_name": "async_trait",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -913,6 +958,9 @@
       ],
       "library_target_name": "atomic_waker",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -943,6 +991,9 @@
       ],
       "library_target_name": "atty",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -996,6 +1047,9 @@
       ],
       "library_target_name": "autocfg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.1"
       },
@@ -1026,6 +1080,9 @@
       ],
       "library_target_name": "base64",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1072,6 +1129,9 @@
       ],
       "library_target_name": "basic_cookies",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1094,8 +1154,7 @@
       },
       "build_script_attrs": {
         "data_glob": [
-          "**",
-          "**/*.lalrpop"
+          "**"
         ],
         "deps": {
           "common": [
@@ -1134,6 +1193,9 @@
       ],
       "library_target_name": "bit_set",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1173,6 +1235,9 @@
       ],
       "library_target_name": "bit_vec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.6.3"
       },
@@ -1203,6 +1268,9 @@
       ],
       "library_target_name": "bitflags",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1236,6 +1304,9 @@
       ],
       "library_target_name": "block_buffer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1275,6 +1346,9 @@
       ],
       "library_target_name": "blocking",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1334,6 +1408,9 @@
       ],
       "library_target_name": "bumpalo",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1367,6 +1444,9 @@
       ],
       "library_target_name": "bytes",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1401,6 +1481,9 @@
       ],
       "library_target_name": "cache_padded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.2.0"
       },
@@ -1431,6 +1514,9 @@
       ],
       "library_target_name": "castaway",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.2"
       },
@@ -1473,6 +1559,9 @@
       ],
       "library_target_name": "cc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.72"
       },
@@ -1503,6 +1592,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -1533,6 +1625,9 @@
       ],
       "library_target_name": "concurrent_queue",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1572,6 +1667,9 @@
       ],
       "library_target_name": "core_foundation",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1627,6 +1725,9 @@
       ],
       "library_target_name": "core_foundation_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1683,6 +1784,9 @@
       ],
       "library_target_name": "crossbeam_utils",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lazy_static",
@@ -1752,6 +1856,9 @@
       ],
       "library_target_name": "crunchy",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "limit_128"
@@ -1800,6 +1907,9 @@
       ],
       "library_target_name": "ctor",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1855,6 +1965,9 @@
       ],
       "library_target_name": "curl",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "http2",
@@ -1949,6 +2062,9 @@
       ],
       "library_target_name": "curl_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "http2",
@@ -2021,6 +2137,9 @@
       ],
       "library_target_name": "diff",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.12"
       },
@@ -2051,6 +2170,9 @@
       ],
       "library_target_name": "digest",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "std"
@@ -2089,6 +2211,9 @@
       ],
       "library_target_name": "direct_cargo_bazel_deps",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.0.1"
       },
@@ -2119,6 +2244,9 @@
       ],
       "library_target_name": "dirs_next",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2162,6 +2290,9 @@
       ],
       "library_target_name": "dirs_sys_next",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -2215,6 +2346,9 @@
       ],
       "library_target_name": "either",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.6.1"
       },
@@ -2245,6 +2379,9 @@
       ],
       "library_target_name": "ena",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2296,6 +2433,9 @@
       ],
       "library_target_name": "encoding_rs",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default"
@@ -2348,6 +2488,9 @@
       ],
       "library_target_name": "event_listener",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "2.5.2"
       },
@@ -2378,6 +2521,9 @@
       ],
       "library_target_name": "fastrand",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -2419,6 +2565,9 @@
       ],
       "library_target_name": "fixedbitset",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.0"
       },
@@ -2449,6 +2598,9 @@
       ],
       "library_target_name": "fnv",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2483,6 +2635,9 @@
       ],
       "library_target_name": "foreign_types",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2522,6 +2677,9 @@
       ],
       "library_target_name": "foreign_types_shared",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.1"
       },
@@ -2552,6 +2710,9 @@
       ],
       "library_target_name": "form_urlencoded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2607,6 +2768,9 @@
       ],
       "library_target_name": "futures_channel",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2672,6 +2836,9 @@
       ],
       "library_target_name": "futures_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2721,6 +2888,9 @@
       ],
       "library_target_name": "futures_io",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2755,6 +2925,9 @@
       ],
       "library_target_name": "futures_lite",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2828,6 +3001,9 @@
       ],
       "library_target_name": "futures_macro",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2875,6 +3051,9 @@
       ],
       "library_target_name": "futures_sink",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2922,6 +3101,9 @@
       ],
       "library_target_name": "futures_task",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "std"
@@ -2982,6 +3164,9 @@
       ],
       "library_target_name": "futures_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "async-await",
@@ -3087,6 +3272,9 @@
       ],
       "library_target_name": "generic_array",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3144,6 +3332,9 @@
       ],
       "library_target_name": "getrandom",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -3199,6 +3390,9 @@
       ],
       "library_target_name": "gloo_timers",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "futures",
@@ -3256,6 +3450,9 @@
       ],
       "library_target_name": "h2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3335,6 +3532,9 @@
       ],
       "library_target_name": "hashbrown",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "raw"
         ],
@@ -3368,6 +3568,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -3410,6 +3613,9 @@
       ],
       "library_target_name": "hex_literal",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.4"
       },
@@ -3440,6 +3646,9 @@
       ],
       "library_target_name": "http",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3487,6 +3696,9 @@
       ],
       "library_target_name": "http_body",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3546,6 +3758,9 @@
       ],
       "library_target_name": "httparse",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -3594,6 +3809,9 @@
       ],
       "library_target_name": "httpdate",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.2"
       },
@@ -3636,6 +3854,9 @@
       ],
       "library_target_name": "httpmock",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "basic-cookies",
           "cookies",
@@ -3761,6 +3982,9 @@
       ],
       "library_target_name": "hyper",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "client",
           "default",
@@ -3871,6 +4095,9 @@
       ],
       "library_target_name": "hyper_tls",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3926,6 +4153,9 @@
       ],
       "library_target_name": "idna",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3985,6 +4215,9 @@
       ],
       "library_target_name": "indexmap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -4045,6 +4278,9 @@
       ],
       "library_target_name": "instant",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4084,6 +4320,9 @@
       ],
       "library_target_name": "ipnet",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "2.3.1"
       },
@@ -4126,6 +4365,9 @@
       ],
       "library_target_name": "isahc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "encoding_rs",
@@ -4254,6 +4496,9 @@
       ],
       "library_target_name": "itertools",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "use_alloc",
           "use_std"
@@ -4297,6 +4542,9 @@
       ],
       "library_target_name": "itoa",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -4331,6 +4579,9 @@
       ],
       "library_target_name": "itoa",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.1"
       },
@@ -4361,6 +4612,9 @@
       ],
       "library_target_name": "js_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4400,6 +4654,9 @@
       ],
       "library_target_name": "kv_log_macro",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4451,6 +4708,9 @@
       ],
       "library_target_name": "lalrpop",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lexer",
@@ -4554,6 +4814,9 @@
       ],
       "library_target_name": "lalrpop_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lexer",
@@ -4599,6 +4862,9 @@
       ],
       "library_target_name": "lazy_static",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.4.0"
       },
@@ -4629,6 +4895,9 @@
       ],
       "library_target_name": "levenshtein",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.5"
       },
@@ -4671,6 +4940,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -4731,6 +5003,9 @@
       ],
       "library_target_name": "libnghttp2_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data_glob": [
           "nghttp2/**"
         ],
@@ -4805,6 +5080,9 @@
       ],
       "library_target_name": "libz_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "libc"
         ],
@@ -4826,8 +5104,7 @@
       },
       "build_script_attrs": {
         "data_glob": [
-          "**",
-          "src/**"
+          "**"
         ],
         "deps": {
           "common": [
@@ -4878,6 +5155,9 @@
       ],
       "library_target_name": "lock_api",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4929,6 +5209,9 @@
       ],
       "library_target_name": "log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "kv_unstable",
           "value-bag"
@@ -4985,6 +5268,9 @@
       ],
       "library_target_name": "matches",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.9"
       },
@@ -5015,6 +5301,9 @@
       ],
       "library_target_name": "md5",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -5078,6 +5367,9 @@
       ],
       "library_target_name": "memchr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -5126,6 +5418,9 @@
       ],
       "library_target_name": "mime",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.3.16"
       },
@@ -5156,6 +5451,9 @@
       ],
       "library_target_name": "mio",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "net",
@@ -5226,6 +5524,9 @@
       ],
       "library_target_name": "miow",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5277,6 +5578,9 @@
       ],
       "library_target_name": "native_tls",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5368,6 +5672,9 @@
       ],
       "library_target_name": "debug_unreachable",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.4"
       },
@@ -5410,6 +5717,9 @@
       ],
       "library_target_name": "ntapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "user"
@@ -5462,6 +5772,9 @@
       ],
       "library_target_name": "num_cpus",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -5509,6 +5822,9 @@
       ],
       "library_target_name": "once_cell",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -5545,6 +5861,9 @@
       ],
       "library_target_name": "opaque_debug",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.0"
       },
@@ -5587,6 +5906,9 @@
       ],
       "library_target_name": "openssl",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5666,6 +5988,9 @@
       ],
       "library_target_name": "openssl_probe",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.5"
       },
@@ -5708,6 +6033,9 @@
       ],
       "library_target_name": "openssl_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "data": {
           "common": [
             "@openssl"
@@ -5805,6 +6133,9 @@
       ],
       "library_target_name": "parking",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "2.0.0"
       },
@@ -5835,6 +6166,9 @@
       ],
       "library_target_name": "parking_lot",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -5897,6 +6231,9 @@
       ],
       "library_target_name": "parking_lot_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -5972,6 +6309,9 @@
       ],
       "library_target_name": "percent_encoding",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "2.1.0"
       },
@@ -6002,6 +6342,9 @@
       ],
       "library_target_name": "petgraph",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6045,6 +6388,9 @@
       ],
       "library_target_name": "phf_shared",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6088,6 +6434,9 @@
       ],
       "library_target_name": "pico_args",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.4.2"
       },
@@ -6118,6 +6467,9 @@
       ],
       "library_target_name": "pin_project",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "proc_macro_deps": {
           "common": [
@@ -6157,6 +6509,9 @@
       ],
       "library_target_name": "pin_project_internal",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6204,6 +6559,9 @@
       ],
       "library_target_name": "pin_project_lite",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.2.8"
       },
@@ -6234,6 +6592,9 @@
       ],
       "library_target_name": "pin_utils",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.0"
       },
@@ -6264,6 +6625,9 @@
       ],
       "library_target_name": "pkg_config",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.3.24"
       },
@@ -6289,6 +6653,9 @@
       ],
       "library_target_name": "pkg_a",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6336,6 +6703,9 @@
       ],
       "library_target_name": "pkg_b",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6370,6 +6740,9 @@
       ],
       "library_target_name": "pkg_c",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6418,6 +6791,9 @@
       ],
       "library_target_name": "polling",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -6482,6 +6858,9 @@
       ],
       "library_target_name": "precomputed_hash",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.1"
       },
@@ -6524,6 +6903,9 @@
       ],
       "library_target_name": "proc_macro2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -6576,6 +6958,9 @@
       ],
       "library_target_name": "quote",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -6619,6 +7004,9 @@
       ],
       "library_target_name": "syscall",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6658,6 +7046,9 @@
       ],
       "library_target_name": "redox_users",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -6701,6 +7092,9 @@
       ],
       "library_target_name": "regex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "aho-corasick",
           "default",
@@ -6767,6 +7161,9 @@
       ],
       "library_target_name": "regex_syntax",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "unicode",
@@ -6808,6 +7205,9 @@
       ],
       "library_target_name": "remove_dir_all",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -6849,6 +7249,9 @@
       ],
       "library_target_name": "reqwest",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "__tls",
           "blocking",
@@ -7027,6 +7430,9 @@
       ],
       "library_target_name": "rustversion",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7071,6 +7477,9 @@
       ],
       "library_target_name": "ryu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.9"
       },
@@ -7101,6 +7510,9 @@
       ],
       "library_target_name": "schannel",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7144,6 +7556,9 @@
       ],
       "library_target_name": "scopeguard",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.1.0"
       },
@@ -7174,6 +7589,9 @@
       ],
       "library_target_name": "security_framework",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "OSX_10_9",
           "default"
@@ -7233,6 +7651,9 @@
       ],
       "library_target_name": "security_framework_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "OSX_10_9",
           "default"
@@ -7292,6 +7713,9 @@
       ],
       "library_target_name": "serde",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "derive",
@@ -7363,6 +7787,9 @@
       ],
       "library_target_name": "serde_derive",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -7434,6 +7861,9 @@
       ],
       "library_target_name": "serde_json",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -7494,6 +7924,9 @@
       ],
       "library_target_name": "serde_regex",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7537,6 +7970,9 @@
       ],
       "library_target_name": "serde_urlencoded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7600,6 +8036,9 @@
       ],
       "library_target_name": "signal_hook",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "channel",
           "iterator"
@@ -7656,6 +8095,9 @@
       ],
       "library_target_name": "signal_hook_registry",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7695,6 +8137,9 @@
       ],
       "library_target_name": "similar",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "text"
@@ -7729,6 +8174,9 @@
       ],
       "library_target_name": "siphasher",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -7763,6 +8211,9 @@
       ],
       "library_target_name": "slab",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -7797,6 +8248,9 @@
       ],
       "library_target_name": "sluice",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7844,6 +8298,9 @@
       ],
       "library_target_name": "smallvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.8.0"
       },
@@ -7874,6 +8331,9 @@
       ],
       "library_target_name": "socket2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "all"
         ],
@@ -7924,6 +8384,9 @@
       ],
       "library_target_name": "string_cache",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -7991,6 +8454,9 @@
       ],
       "library_target_name": "syn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "clone-impls",
           "default",
@@ -8060,6 +8526,9 @@
       ],
       "library_target_name": "tempfile",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -8126,6 +8595,9 @@
       ],
       "library_target_name": "term",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -8198,6 +8670,9 @@
       ],
       "library_target_name": "tiny_keccak",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "sha3"
@@ -8250,6 +8725,9 @@
       ],
       "library_target_name": "tinyvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -8294,6 +8772,9 @@
       ],
       "library_target_name": "tinyvec_macros",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.0"
       },
@@ -8324,6 +8805,9 @@
       ],
       "library_target_name": "tokio",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "bytes",
           "default",
@@ -8429,6 +8913,9 @@
       ],
       "library_target_name": "tokio_macros",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -8476,6 +8963,9 @@
       ],
       "library_target_name": "tokio_native_tls",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -8519,6 +9009,9 @@
       ],
       "library_target_name": "tokio_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "codec",
           "default"
@@ -8582,6 +9075,9 @@
       ],
       "library_target_name": "tower_service",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -8612,6 +9108,9 @@
       ],
       "library_target_name": "tracing",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "attributes",
           "default",
@@ -8679,6 +9178,9 @@
       ],
       "library_target_name": "tracing_attributes",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -8726,6 +9228,9 @@
       ],
       "library_target_name": "tracing_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "lazy_static",
           "std"
@@ -8769,6 +9274,9 @@
       ],
       "library_target_name": "tracing_futures",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "pin-project",
           "std",
@@ -8817,6 +9325,9 @@
       ],
       "library_target_name": "try_lock",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.3"
       },
@@ -8859,6 +9370,9 @@
       ],
       "library_target_name": "typenum",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -8903,6 +9417,9 @@
       ],
       "library_target_name": "unicode_bidi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -8937,6 +9454,9 @@
       ],
       "library_target_name": "unicode_normalization",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -8980,6 +9500,9 @@
       ],
       "library_target_name": "unicode_xid",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -9013,6 +9536,9 @@
       ],
       "library_target_name": "url",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9076,6 +9602,9 @@
       ],
       "library_target_name": "value_bag",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9139,6 +9668,9 @@
       ],
       "library_target_name": "vcpkg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.15"
       },
@@ -9169,6 +9701,9 @@
       ],
       "library_target_name": "version_check",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.9.4"
       },
@@ -9199,6 +9734,9 @@
       ],
       "library_target_name": "waker_fn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.1.0"
       },
@@ -9229,6 +9767,9 @@
       ],
       "library_target_name": "want",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9272,6 +9813,9 @@
       ],
       "library_target_name": "wasi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -9318,6 +9862,9 @@
       ],
       "library_target_name": "wasm_bindgen",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "spans",
@@ -9380,6 +9927,9 @@
       ],
       "library_target_name": "wasm_bindgen_backend",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "spans"
         ],
@@ -9446,6 +9996,9 @@
       ],
       "library_target_name": "wasm_bindgen_futures",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9500,6 +10053,9 @@
       ],
       "library_target_name": "wasm_bindgen_macro",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "spans"
         ],
@@ -9546,6 +10102,9 @@
       ],
       "library_target_name": "wasm_bindgen_macro_support",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "spans"
         ],
@@ -9616,6 +10175,9 @@
       ],
       "library_target_name": "wasm_bindgen_shared",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9661,6 +10223,9 @@
       ],
       "library_target_name": "web_sys",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "Blob",
           "BlobPropertyBag",
@@ -9735,6 +10300,9 @@
       ],
       "library_target_name": "wepoll_ffi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "null-overlapped-wakeups-patch"
         ],
@@ -9804,6 +10372,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "cfg",
           "consoleapi",
@@ -9920,6 +10491,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -9976,6 +10550,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -10020,6 +10597,9 @@
       ],
       "library_target_name": "winreg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "f1f3fb003c2bc622425be211aadbf873e3e309b60c6837988dec265214b17392",
+  "checksum": "adabeea6f7e636e75e98fa9bc30610bc8e0ff560d22094352a2efdbdbace659c",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -26,6 +26,9 @@
       ],
       "library_target_name": "ansi_term",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -79,6 +82,9 @@
       ],
       "library_target_name": "async_trait",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -135,6 +141,9 @@
       ],
       "library_target_name": "autocfg",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.0.1"
       },
@@ -166,6 +175,7 @@
       "library_target_name": "axum",
       "common_attrs": {
         "compile_data_glob": [
+          "**",
           "**/*.md"
         ],
         "crate_features": [
@@ -307,6 +317,9 @@
       ],
       "library_target_name": "axum_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -371,6 +384,9 @@
       ],
       "library_target_name": "bitflags",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -404,6 +420,9 @@
       ],
       "library_target_name": "bytes",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -438,6 +457,9 @@
       ],
       "library_target_name": "cfg_if",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.0"
       },
@@ -463,6 +485,9 @@
       ],
       "library_target_name": "direct_cargo_bazel_deps",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -534,6 +559,9 @@
       ],
       "library_target_name": "fnv",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -568,6 +596,9 @@
       ],
       "library_target_name": "form_urlencoded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -623,6 +654,9 @@
       ],
       "library_target_name": "futures_channel",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -688,6 +722,9 @@
       ],
       "library_target_name": "futures_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -737,6 +774,9 @@
       ],
       "library_target_name": "futures_sink",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -784,6 +824,9 @@
       ],
       "library_target_name": "futures_task",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc"
         ],
@@ -843,6 +886,9 @@
       ],
       "library_target_name": "futures_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc"
         ],
@@ -906,6 +952,9 @@
       ],
       "library_target_name": "h2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -985,6 +1034,9 @@
       ],
       "library_target_name": "hashbrown",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "raw"
         ],
@@ -1018,6 +1070,9 @@
       ],
       "library_target_name": "hermit_abi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1060,6 +1115,9 @@
       ],
       "library_target_name": "http",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1107,6 +1165,9 @@
       ],
       "library_target_name": "http_body",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1154,6 +1215,9 @@
       ],
       "library_target_name": "http_range_header",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.0"
       },
@@ -1196,6 +1260,9 @@
       ],
       "library_target_name": "httparse",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1244,6 +1311,9 @@
       ],
       "library_target_name": "httpdate",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.2"
       },
@@ -1274,6 +1344,9 @@
       ],
       "library_target_name": "hyper",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "client",
           "default",
@@ -1398,6 +1471,9 @@
       ],
       "library_target_name": "indexmap",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -1458,6 +1534,9 @@
       ],
       "library_target_name": "instant",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1497,6 +1576,9 @@
       ],
       "library_target_name": "itoa",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1531,6 +1613,9 @@
       ],
       "library_target_name": "itoa",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.1"
       },
@@ -1561,6 +1646,9 @@
       ],
       "library_target_name": "lazy_static",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.4.0"
       },
@@ -1603,6 +1691,9 @@
       ],
       "library_target_name": "libc",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1651,6 +1742,9 @@
       ],
       "library_target_name": "lock_api",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -1702,6 +1796,9 @@
       ],
       "library_target_name": "log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "std"
         ],
@@ -1753,6 +1850,9 @@
       ],
       "library_target_name": "matches",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.1.9"
       },
@@ -1783,6 +1883,9 @@
       ],
       "library_target_name": "matchit",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -1828,6 +1931,9 @@
       ],
       "library_target_name": "memchr",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -1876,6 +1982,9 @@
       ],
       "library_target_name": "mime",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.3.16"
       },
@@ -1906,6 +2015,9 @@
       ],
       "library_target_name": "mio",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "net",
@@ -1976,6 +2088,9 @@
       ],
       "library_target_name": "miow",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2027,6 +2142,9 @@
       ],
       "library_target_name": "ntapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "user"
@@ -2079,6 +2197,9 @@
       ],
       "library_target_name": "num_cpus",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -2126,6 +2247,9 @@
       ],
       "library_target_name": "once_cell",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "default",
@@ -2162,6 +2286,9 @@
       ],
       "library_target_name": "parking_lot",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -2224,6 +2351,9 @@
       ],
       "library_target_name": "parking_lot_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2299,6 +2429,9 @@
       ],
       "library_target_name": "percent_encoding",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "2.1.0"
       },
@@ -2329,6 +2462,9 @@
       ],
       "library_target_name": "pin_project",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "proc_macro_deps": {
           "common": [
@@ -2368,6 +2504,9 @@
       ],
       "library_target_name": "pin_project_internal",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2415,6 +2554,9 @@
       ],
       "library_target_name": "pin_project_lite",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.2.8"
       },
@@ -2445,6 +2587,9 @@
       ],
       "library_target_name": "pin_utils",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.0"
       },
@@ -2487,6 +2632,9 @@
       ],
       "library_target_name": "proc_macro2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -2539,6 +2687,9 @@
       ],
       "library_target_name": "quote",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "proc-macro"
@@ -2582,6 +2733,9 @@
       ],
       "library_target_name": "syscall",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2621,6 +2775,9 @@
       ],
       "library_target_name": "ryu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.0.9"
       },
@@ -2651,6 +2808,9 @@
       ],
       "library_target_name": "scopeguard",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "1.1.0"
       },
@@ -2693,6 +2853,9 @@
       ],
       "library_target_name": "serde",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2753,6 +2916,9 @@
       ],
       "library_target_name": "serde_json",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "raw_value",
@@ -2814,6 +2980,9 @@
       ],
       "library_target_name": "serde_urlencoded",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2865,6 +3034,9 @@
       ],
       "library_target_name": "sharded_slab",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2904,6 +3076,9 @@
       ],
       "library_target_name": "signal_hook_registry",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -2943,6 +3118,9 @@
       ],
       "library_target_name": "slab",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "std"
@@ -2977,6 +3155,9 @@
       ],
       "library_target_name": "smallvec",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "1.8.0"
       },
@@ -3007,6 +3188,9 @@
       ],
       "library_target_name": "socket2",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [],
           "selects": {
@@ -3066,6 +3250,9 @@
       ],
       "library_target_name": "syn",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "clone-impls",
           "default",
@@ -3135,6 +3322,9 @@
       ],
       "library_target_name": "sync_wrapper",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.1.1"
       },
@@ -3165,6 +3355,9 @@
       ],
       "library_target_name": "thread_local",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3204,6 +3397,9 @@
       ],
       "library_target_name": "tokio",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "bytes",
           "default",
@@ -3318,6 +3514,9 @@
       ],
       "library_target_name": "tokio_macros",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3365,6 +3564,9 @@
       ],
       "library_target_name": "tokio_util",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "codec",
           "default"
@@ -3428,6 +3630,9 @@
       ],
       "library_target_name": "tower",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "buffer",
           "default",
@@ -3510,6 +3715,9 @@
       ],
       "library_target_name": "tower_http",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "map-response-body",
@@ -3595,6 +3803,9 @@
       ],
       "library_target_name": "tower_layer",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -3625,6 +3836,9 @@
       ],
       "library_target_name": "tower_service",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2018",
         "version": "0.3.1"
       },
@@ -3655,6 +3869,9 @@
       ],
       "library_target_name": "tracing",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "attributes",
           "default",
@@ -3722,6 +3939,9 @@
       ],
       "library_target_name": "tracing_attributes",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -3769,6 +3989,9 @@
       ],
       "library_target_name": "tracing_core",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default",
           "lazy_static",
@@ -3813,6 +4036,9 @@
       ],
       "library_target_name": "tracing_log",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "log-tracer",
           "std"
@@ -3864,6 +4090,9 @@
       ],
       "library_target_name": "tracing_subscriber",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "alloc",
           "ansi",
@@ -3936,6 +4165,9 @@
       ],
       "library_target_name": "try_lock",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "edition": "2015",
         "version": "0.2.3"
       },
@@ -3966,6 +4198,9 @@
       ],
       "library_target_name": "unicode_xid",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "default"
         ],
@@ -3999,6 +4234,9 @@
       ],
       "library_target_name": "want",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4054,6 +4292,9 @@
       ],
       "library_target_name": "winapi",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "crate_features": [
           "cfg",
           "consoleapi",
@@ -4155,6 +4396,9 @@
       ],
       "library_target_name": "winapi_i686_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {
@@ -4211,6 +4455,9 @@
       ],
       "library_target_name": "winapi_x86_64_pc_windows_gnu",
       "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
         "deps": {
           "common": [
             {

--- a/tools/cargo_bazel/src/context/crate_context.rs
+++ b/tools/cargo_bazel/src/context/crate_context.rs
@@ -54,7 +54,7 @@ pub enum Rule {
 
 /// A set of attributes common to most `rust_library`, `rust_proc_macro`, and other
 /// [core rules of `rules_rust`](https://bazelbuild.github.io/rules_rust/defs.html).
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct CommonAttributes {
     #[serde(skip_serializing_if = "SelectStringList::should_skip_serializing")]
@@ -108,6 +108,32 @@ pub struct CommonAttributes {
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+}
+
+impl Default for CommonAttributes {
+    fn default() -> Self {
+        Self {
+            compile_data: Default::default(),
+            // Generated targets include all files in their package by default
+            compile_data_glob: BTreeSet::from(["**".to_owned()]),
+            crate_features: Default::default(),
+            data: Default::default(),
+            data_glob: Default::default(),
+            deps: Default::default(),
+            extra_deps: Default::default(),
+            deps_dev: Default::default(),
+            edition: Default::default(),
+            linker_script: Default::default(),
+            proc_macro_deps: Default::default(),
+            extra_proc_macro_deps: Default::default(),
+            proc_macro_deps_dev: Default::default(),
+            rustc_env: Default::default(),
+            rustc_env_files: Default::default(),
+            rustc_flags: Default::default(),
+            version: Default::default(),
+            tags: Default::default(),
+        }
+    }
 }
 
 // Build script attributes. See


### PR DESCRIPTION
This change requires https://github.com/bazelbuild/rules_rust/commit/5776967a2a9986d52a34e2c3604ed662ed47e21f which was introduced in https://github.com/abrisco/cargo-bazel/pull/138