### PR TITLE
Added support for `additive_build_file` annotations

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "ee9a5e0c573f0aaa9b047ecd0a9421c68bac5f2235567b306da9931cfc0e5daf",
+  "checksum": "f04a8b927849ca899178faa953e5039f32596d2b23300ca33a467ae6e3e998a9",
   "crates": {
     "adler 1.0.2": {
       "name": "adler",
@@ -268,13 +268,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "block-buffer 0.10.0": {
+    "block-buffer 0.10.1": {
       "name": "block-buffer",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.0/download",
-          "sha256": "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+          "url": "https://crates.io/api/v1/crates/block-buffer/0.10.1/download",
+          "sha256": "03588e54c62ae6d763e2a80090d50353b785795361b4ff5b3bf0a5097fc31c0b"
         }
       },
       "targets": [
@@ -306,7 +306,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.10.0"
+        "version": "0.10.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -650,7 +650,7 @@
               "target": "clap"
             },
             {
-              "id": "crates-index 0.18.4",
+              "id": "crates-index 0.18.5",
               "target": "crates_index"
             },
             {
@@ -666,7 +666,7 @@
               "target": "regex"
             },
             {
-              "id": "semver 1.0.4",
+              "id": "semver 1.0.5",
               "target": "semver"
             },
             {
@@ -757,7 +757,7 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.4",
+              "id": "semver 1.0.5",
               "target": "semver"
             },
             {
@@ -864,7 +864,7 @@
               "target": "cargo_platform"
             },
             {
-              "id": "semver 1.0.4",
+              "id": "semver 1.0.5",
               "target": "semver"
             },
             {
@@ -1467,13 +1467,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crates-index 0.18.4": {
+    "crates-index 0.18.5": {
       "name": "crates-index",
-      "version": "0.18.4",
+      "version": "0.18.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crates-index/0.18.4/download",
-          "sha256": "2679f1aadf9fc356f8233e82d048bf3fc048f68de3d95a1e40c29bb0a012e9bf"
+          "url": "https://crates.io/api/v1/crates/crates-index/0.18.5/download",
+          "sha256": "00c338c128681bf06772e2a188f7937293620478bb7781e453e996266686e806"
         }
       },
       "targets": [
@@ -1514,7 +1514,15 @@
               "target": "memchr"
             },
             {
-              "id": "semver 1.0.4",
+              "id": "num_cpus 1.13.1",
+              "target": "num_cpus"
+            },
+            {
+              "id": "rustc-hash 1.1.0",
+              "target": "rustc_hash"
+            },
+            {
+              "id": "semver 1.0.5",
               "target": "semver"
             },
             {
@@ -1542,7 +1550,7 @@
           ],
           "selects": {}
         },
-        "version": "0.18.4"
+        "version": "0.18.5"
       },
       "license": "Apache-2.0"
     },
@@ -1650,13 +1658,13 @@
       },
       "license": null
     },
-    "crossbeam-utils 0.8.6": {
+    "crossbeam-utils 0.8.7": {
       "name": "crossbeam-utils",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.6/download",
-          "sha256": "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.7/download",
+          "sha256": "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
         }
       },
       "targets": [
@@ -1702,7 +1710,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "build_script_build"
             },
             {
@@ -1713,7 +1721,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.6"
+        "version": "0.8.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -1838,7 +1846,7 @@
         "deps": {
           "common": [
             {
-              "id": "block-buffer 0.10.0",
+              "id": "block-buffer 0.10.1",
               "target": "block_buffer"
             },
             {
@@ -2958,7 +2966,7 @@
         "deps": {
           "common": [
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "crossbeam_utils"
             },
             {
@@ -4125,6 +4133,56 @@
           ],
           "selects": {}
         }
+      },
+      "license": "MIT OR Apache-2.0"
+    },
+    "num_cpus 1.13.1": {
+      "name": "num_cpus",
+      "version": "1.13.1",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/num_cpus/1.13.1/download",
+          "sha256": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "num_cpus",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "num_cpus",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [
+              {
+                "id": "hermit-abi 0.1.19",
+                "target": "hermit_abi"
+              }
+            ],
+            "cfg(not(windows))": [
+              {
+                "id": "libc 0.2.117",
+                "target": "libc"
+              }
+            ]
+          }
+        },
+        "edition": "2015",
+        "version": "1.13.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -5701,6 +5759,43 @@
       },
       "license": "MIT/Apache-2.0"
     },
+    "rustc-hash 1.1.0": {
+      "name": "rustc-hash",
+      "version": "1.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/rustc-hash/1.1.0/download",
+          "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "rustc_hash",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "rustc_hash",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "default",
+          "std"
+        ],
+        "edition": "2015",
+        "version": "1.1.0"
+      },
+      "license": "Apache-2.0/MIT"
+    },
     "rustc-serialize 0.3.24": {
       "name": "rustc-serialize",
       "version": "0.3.24",
@@ -5811,13 +5906,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "semver 1.0.4": {
+    "semver 1.0.5": {
       "name": "semver",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/semver/1.0.4/download",
-          "sha256": "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+          "url": "https://crates.io/api/v1/crates/semver/1.0.5/download",
+          "sha256": "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
         }
       },
       "targets": [
@@ -5859,7 +5954,7 @@
         "deps": {
           "common": [
             {
-              "id": "semver 1.0.4",
+              "id": "semver 1.0.5",
               "target": "build_script_build"
             },
             {
@@ -5870,7 +5965,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8312,6 +8407,7 @@
     "urls_generator 0.1.0": "tools/urls_generator"
   },
   "conditions": {
+    "cfg(all(any(target_arch = \"x86_64\", target_arch = \"aarch64\"), target_os = \"hermit\"))": [],
     "cfg(any(target_arch = \"aarch64\", target_arch = \"x86_64\", target_arch = \"x86\"))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -8367,6 +8463,26 @@
       "x86_64-apple-ios",
       "x86_64-linux-android",
       "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
+    "cfg(not(windows))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu"
     ],

--- a/defs.bzl
+++ b/defs.bzl
@@ -292,9 +292,22 @@ def _spec(
         rev = rev,
     ))
 
+def _assert_absolute(label):
+    """Ensure a given label is an absolute label
+
+    Args:
+        label (Label): The label to check
+    """
+    label_str = str(label)
+    if not label.startswith("@"):
+        fail("The labels must be absolute. Please update '{}'".format(
+            label_str,
+        ))
+
 def _annotation(
         version = "*",
-        build_content = None,
+        additive_build_file = None,
+        additive_build_file_content = None,
         build_script_data = None,
         build_script_data_glob = None,
         build_script_deps = None,
@@ -320,7 +333,9 @@ def _annotation(
 
     Args:
         version (str, optional): The version or semver-conditions to match with a crate.
-        build_content (str, optional): Extra contents to write to the bottom of generated BUILD files.
+        additive_build_file_content (str, optional): Extra contents to write to the bottom of generated BUILD files.
+        additive_build_file (str, optional): A file containing extra contents to write to the bottom of
+            generated BUILD files.
         build_script_data (list, optional): A list of labels to add to a crate's `cargo_build_script::data` attribute.
         build_script_data_glob (list, optional): A list of glob patterns to add to a crate's `cargo_build_script::data`
             attribute.
@@ -359,10 +374,17 @@ def _annotation(
     Returns:
         string: A json encoded string containing the specified version and separately all other inputs.
     """
+    if additive_build_file:
+        _assert_absolute(additive_build_file)
+    if patches:
+        for patch in patches:
+            _assert_absolute(patch)
+
     return json.encode((
         version,
         struct(
-            build_content = build_content,
+            additive_build_file = additive_build_file,
+            additive_build_file_content = additive_build_file_content,
             build_script_data = build_script_data,
             build_script_data_glob = build_script_data_glob,
             build_script_deps = build_script_deps,

--- a/examples/extra_workspace_members/Cargo.Bazel.lock
+++ b/examples/extra_workspace_members/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "431cb8fc1e6470cc10ed3862c518b16823042f1146c6f42d4fb7e0e785bdab74",
+  "checksum": "b5f7ddbb115ce0dac2dee09e355c63071a3028a5c80e75258f7910b696e5fbed",
   "crates": {
     "adler32 1.2.0": {
       "name": "adler32",
@@ -563,13 +563,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "crossbeam-utils 0.8.6": {
+    "crossbeam-utils 0.8.7": {
       "name": "crossbeam-utils",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.6/download",
-          "sha256": "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.7/download",
+          "sha256": "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
         }
       },
       "targets": [
@@ -615,7 +615,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "build_script_build"
             },
             {
@@ -626,7 +626,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.6"
+        "version": "0.8.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -2650,7 +2650,7 @@
           "selects": {
             "cfg(not(target_arch = \"wasm32\"))": [
               {
-                "id": "crossbeam-utils 0.8.6",
+                "id": "crossbeam-utils 0.8.7",
                 "target": "crossbeam_utils"
               }
             ]

--- a/examples/multi_package/Cargo.Bazel.lock
+++ b/examples/multi_package/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "8c02d9c1beaefeedef2e1ac159bdd85973a85ba32a80f7ef50046b260d0f855c",
+  "checksum": "0327535caaa8aead5fe05487033967307825aa3a92c02a9c94c8e8a928e96a2e",
   "crates": {
     "aho-corasick 0.7.18": {
       "name": "aho-corasick",
@@ -741,7 +741,7 @@
               "target": "async_lock"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "crossbeam_utils"
             },
             {
@@ -1747,13 +1747,13 @@
       },
       "license": "MIT / Apache-2.0"
     },
-    "crossbeam-utils 0.8.6": {
+    "crossbeam-utils 0.8.7": {
       "name": "crossbeam-utils",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.6/download",
-          "sha256": "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+          "url": "https://crates.io/api/v1/crates/crossbeam-utils/0.8.7/download",
+          "sha256": "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
         }
       },
       "targets": [
@@ -1799,7 +1799,7 @@
               "target": "cfg_if"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "build_script_build"
             },
             {
@@ -1810,7 +1810,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.6"
+        "version": "0.8.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -3496,7 +3496,7 @@
               "target": "tokio_util"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             }
           ],
@@ -3881,7 +3881,7 @@
               "target": "basic_cookies"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "crossbeam_utils"
             },
             {
@@ -4055,7 +4055,7 @@
               "target": "tower_service"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             },
             {
@@ -4387,7 +4387,7 @@
               "target": "castaway"
             },
             {
-              "id": "crossbeam-utils 0.8.6",
+              "id": "crossbeam-utils 0.8.7",
               "target": "crossbeam_utils"
             },
             {
@@ -4443,7 +4443,7 @@
               "target": "sluice"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             },
             {
@@ -4766,7 +4766,7 @@
               "target": "regex_syntax"
             },
             {
-              "id": "string_cache 0.8.2",
+              "id": "string_cache 0.8.3",
               "target": "string_cache"
             },
             {
@@ -5599,11 +5599,11 @@
                 "target": "libc"
               },
               {
-                "id": "security-framework 2.6.0",
+                "id": "security-framework 2.6.1",
                 "target": "security_framework"
               },
               {
-                "id": "security-framework-sys 2.6.0",
+                "id": "security-framework-sys 2.6.1",
                 "target": "security_framework_sys"
               },
               {
@@ -6363,13 +6363,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "phf_shared 0.8.0": {
+    "phf_shared 0.10.0": {
       "name": "phf_shared",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/phf_shared/0.8.0/download",
-          "sha256": "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+          "url": "https://crates.io/api/v1/crates/phf_shared/0.10.0/download",
+          "sha256": "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
         }
       },
       "targets": [
@@ -6405,7 +6405,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.0"
+        "version": "0.10.0"
       },
       "license": "MIT"
     },
@@ -7564,13 +7564,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "security-framework 2.6.0": {
+    "security-framework 2.6.1": {
       "name": "security-framework",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/security-framework/2.6.0/download",
-          "sha256": "3fed7948b6c68acbb6e20c334f55ad635dc0f75506963de4464289fbd3b051ac"
+          "url": "https://crates.io/api/v1/crates/security-framework/2.6.1/download",
+          "sha256": "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
         }
       },
       "targets": [
@@ -7615,24 +7615,24 @@
               "target": "libc"
             },
             {
-              "id": "security-framework-sys 2.6.0",
+              "id": "security-framework-sys 2.6.1",
               "target": "security_framework_sys"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.6.0"
+        "version": "2.6.1"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "security-framework-sys 2.6.0": {
+    "security-framework-sys 2.6.1": {
       "name": "security-framework-sys",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/security-framework-sys/2.6.0/download",
-          "sha256": "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+          "url": "https://crates.io/api/v1/crates/security-framework-sys/2.6.1/download",
+          "sha256": "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
         }
       },
       "targets": [
@@ -7672,7 +7672,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "2.6.0"
+        "version": "2.6.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8359,13 +8359,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "string_cache 0.8.2": {
+    "string_cache 0.8.3": {
       "name": "string_cache",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/string_cache/0.8.2/download",
-          "sha256": "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
+          "url": "https://crates.io/api/v1/crates/string_cache/0.8.3/download",
+          "sha256": "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
         }
       },
       "targets": [
@@ -8402,7 +8402,7 @@
               "target": "parking_lot"
             },
             {
-              "id": "phf_shared 0.8.0",
+              "id": "phf_shared 0.10.0",
               "target": "phf_shared"
             },
             {
@@ -8413,7 +8413,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.8.2"
+        "version": "0.8.3"
       },
       "license": "MIT / Apache-2.0"
     },
@@ -9083,13 +9083,13 @@
       },
       "license": "MIT"
     },
-    "tracing 0.1.29": {
+    "tracing 0.1.30": {
       "name": "tracing",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing/0.1.29/download",
-          "sha256": "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+          "url": "https://crates.io/api/v1/crates/tracing/0.1.30/download",
+          "sha256": "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
         }
       },
       "targets": [
@@ -9133,7 +9133,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.21",
+              "id": "tracing-core 0.1.22",
               "target": "tracing_core"
             }
           ],
@@ -9143,23 +9143,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tracing-attributes 0.1.18",
+              "id": "tracing-attributes 0.1.19",
               "target": "tracing_attributes"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.29"
+        "version": "0.1.30"
       },
       "license": "MIT"
     },
-    "tracing-attributes 0.1.18": {
+    "tracing-attributes 0.1.19": {
       "name": "tracing-attributes",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.18/download",
-          "sha256": "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.19/download",
+          "sha256": "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
         }
       },
       "targets": [
@@ -9199,17 +9199,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.18"
+        "version": "0.1.19"
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.21": {
+    "tracing-core 0.1.22": {
       "name": "tracing-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.21/download",
-          "sha256": "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.22/download",
+          "sha256": "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
         }
       },
       "targets": [
@@ -9245,7 +9245,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.21"
+        "version": "0.1.22"
       },
       "license": "MIT"
     },
@@ -9289,7 +9289,7 @@
               "target": "pin_project"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             }
           ],

--- a/examples/no_cargo_manifests/Cargo.Bazel.lock
+++ b/examples/no_cargo_manifests/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "4c89ffa81109db881a007775d9dd1969705402d550672f570bed548874829a1d",
+  "checksum": "9108e6befed99657572404f077c33b36da679cc113f083b6454a0eda0badae47",
   "crates": {
     "ansi_term 0.12.1": {
       "name": "ansi_term",
@@ -519,11 +519,11 @@
               "target": "tower_http"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             },
             {
-              "id": "tracing-subscriber 0.3.7",
+              "id": "tracing-subscriber 0.3.8",
               "target": "tracing_subscriber"
             }
           ],
@@ -998,7 +998,7 @@
               "target": "tokio_util"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             }
           ],
@@ -1419,7 +1419,7 @@
               "target": "tower_service"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             },
             {
@@ -3679,7 +3679,7 @@
               "target": "tower_service"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             }
           ],
@@ -3767,7 +3767,7 @@
               "target": "tower_service"
             },
             {
-              "id": "tracing 0.1.29",
+              "id": "tracing 0.1.30",
               "target": "tracing"
             }
           ],
@@ -3844,13 +3844,13 @@
       },
       "license": "MIT"
     },
-    "tracing 0.1.29": {
+    "tracing 0.1.30": {
       "name": "tracing",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing/0.1.29/download",
-          "sha256": "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+          "url": "https://crates.io/api/v1/crates/tracing/0.1.30/download",
+          "sha256": "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
         }
       },
       "targets": [
@@ -3894,7 +3894,7 @@
               "target": "pin_project_lite"
             },
             {
-              "id": "tracing-core 0.1.21",
+              "id": "tracing-core 0.1.22",
               "target": "tracing_core"
             }
           ],
@@ -3904,23 +3904,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "tracing-attributes 0.1.18",
+              "id": "tracing-attributes 0.1.19",
               "target": "tracing_attributes"
             }
           ],
           "selects": {}
         },
-        "version": "0.1.29"
+        "version": "0.1.30"
       },
       "license": "MIT"
     },
-    "tracing-attributes 0.1.18": {
+    "tracing-attributes 0.1.19": {
       "name": "tracing-attributes",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.18/download",
-          "sha256": "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+          "url": "https://crates.io/api/v1/crates/tracing-attributes/0.1.19/download",
+          "sha256": "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
         }
       },
       "targets": [
@@ -3960,17 +3960,17 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.1.18"
+        "version": "0.1.19"
       },
       "license": "MIT"
     },
-    "tracing-core 0.1.21": {
+    "tracing-core 0.1.22": {
       "name": "tracing-core",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.21/download",
-          "sha256": "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+          "url": "https://crates.io/api/v1/crates/tracing-core/0.1.22/download",
+          "sha256": "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
         }
       },
       "targets": [
@@ -3995,7 +3995,8 @@
         "crate_features": [
           "default",
           "lazy_static",
-          "std"
+          "std",
+          "valuable"
         ],
         "deps": {
           "common": [
@@ -4004,10 +4005,17 @@
               "target": "lazy_static"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(tracing_unstable)": [
+              {
+                "id": "valuable 0.1.0",
+                "target": "valuable"
+              }
+            ]
+          }
         },
         "edition": "2018",
-        "version": "0.1.21"
+        "version": "0.1.22"
       },
       "license": "MIT"
     },
@@ -4054,7 +4062,7 @@
               "target": "log"
             },
             {
-              "id": "tracing-core 0.1.21",
+              "id": "tracing-core 0.1.22",
               "target": "tracing_core"
             }
           ],
@@ -4065,13 +4073,13 @@
       },
       "license": "MIT"
     },
-    "tracing-subscriber 0.3.7": {
+    "tracing-subscriber 0.3.8": {
       "name": "tracing-subscriber",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.7/download",
-          "sha256": "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+          "url": "https://crates.io/api/v1/crates/tracing-subscriber/0.3.8/download",
+          "sha256": "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
         }
       },
       "targets": [
@@ -4125,7 +4133,7 @@
               "target": "thread_local"
             },
             {
-              "id": "tracing-core 0.1.21",
+              "id": "tracing-core 0.1.22",
               "target": "tracing_core"
             },
             {
@@ -4136,7 +4144,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.7"
+        "version": "0.3.8"
       },
       "license": "MIT"
     },
@@ -4208,6 +4216,69 @@
         "version": "0.2.2"
       },
       "license": "MIT OR Apache-2.0"
+    },
+    "valuable 0.1.0": {
+      "name": "valuable",
+      "version": "0.1.0",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/valuable/0.1.0/download",
+          "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "valuable",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        },
+        {
+          "BuildScript": {
+            "crate_name": "build_script_build",
+            "crate_root": "build.rs",
+            "srcs": {
+              "include": [
+                "**/*.rs"
+              ],
+              "exclude": []
+            }
+          }
+        }
+      ],
+      "library_target_name": "valuable",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "crate_features": [
+          "alloc",
+          "std"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "valuable 0.1.0",
+              "target": "build_script_build"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.1.0"
+      },
+      "build_script_attrs": {
+        "data_glob": [
+          "**"
+        ]
+      },
+      "license": "MIT"
     },
     "want 0.3.0": {
       "name": "want",
@@ -4511,6 +4582,7 @@
       "i686-pc-windows-msvc",
       "x86_64-pc-windows-msvc"
     ],
+    "cfg(tracing_unstable)": [],
     "cfg(unix)": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",

--- a/tools/cargo_bazel/src/config.rs
+++ b/tools/cargo_bazel/src/config.rs
@@ -168,7 +168,7 @@ pub struct CrateAnnotations {
     pub build_script_rustc_env: Option<BTreeMap<String, String>>,
 
     /// A scratch pad used to write arbitrary text to target BUILD files.
-    pub build_content: Option<String>,
+    pub additive_build_file_content: Option<String>,
 
     /// For git sourced crates, this is a the
     /// [git_repository::shallow_since](https://docs.bazel.build/versions/main/repo/git.html#new_git_repository-shallow_since) attribute.
@@ -258,7 +258,7 @@ impl Add for CrateAnnotations {
             build_script_data_glob: joined_extra_member!(self.build_script_data_glob, rhs.build_script_data_glob, BTreeSet::new, BTreeSet::extend),
             build_script_env: joined_extra_member!(self.build_script_env, rhs.build_script_env, BTreeMap::new, BTreeMap::extend),
             build_script_rustc_env: joined_extra_member!(self.build_script_rustc_env, rhs.build_script_rustc_env, BTreeMap::new, BTreeMap::extend),
-            build_content: joined_extra_member!(self.build_content, rhs.build_content, String::new, concat_string),
+            additive_build_file_content: joined_extra_member!(self.additive_build_file_content, rhs.additive_build_file_content, String::new, concat_string),
             shallow_since,
             patch_args: joined_extra_member!(self.patch_args, rhs.patch_args, Vec::new, Vec::extend),
             patch_tool,

--- a/tools/cargo_bazel/src/context/crate_context.rs
+++ b/tools/cargo_bazel/src/context/crate_context.rs
@@ -236,7 +236,7 @@ pub struct CrateContext {
 
     /// Additional text to add to the generated BUILD file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extra_build_contents: Option<String>,
+    pub additive_build_file_content: Option<String>,
 }
 
 impl CrateContext {
@@ -363,7 +363,7 @@ impl CrateContext {
             common_attrs,
             build_script_attrs,
             license,
-            extra_build_contents: None,
+            additive_build_file_content: None,
         }
         .with_overrides(extras)
     }
@@ -473,10 +473,13 @@ impl CrateContext {
             }
 
             // Extra build contents
-            self.extra_build_contents = crate_extra.build_content.as_ref().map(|content| {
-                // For prettier rendering, dedent the build contents
-                textwrap::dedent(content)
-            });
+            self.additive_build_file_content = crate_extra
+                .additive_build_file_content
+                .as_ref()
+                .map(|content| {
+                    // For prettier rendering, dedent the build contents
+                    textwrap::dedent(content)
+                });
 
             // Git shallow_since
             if let Some(SourceAnnotation::Git { shallow_since, .. }) = &mut self.repository {

--- a/tools/cargo_bazel/src/lockfile.rs
+++ b/tools/cargo_bazel/src/lockfile.rs
@@ -285,7 +285,7 @@ mod test {
 
         assert_eq!(
             digest,
-            Digest("34046dacd22ab4ed4bc66d50da5239d762927d5285342f3b570e74a5344dc674".to_owned())
+            Digest("650466aa6ef08620ebf22c117ab0b2f483e01202ed259b222d7c91b081ad382b".to_owned())
         );
     }
 

--- a/tools/cargo_bazel/src/rendering.rs
+++ b/tools/cargo_bazel/src/rendering.rs
@@ -269,4 +269,31 @@ mod test {
         assert!(build_file_content.contains("rust_binary("));
         assert!(build_file_content.contains("name = \"mock_crate__bin\""));
     }
+
+    #[test]
+    fn render_additive_build_contents() {
+        let mut context = Context::default();
+        let crate_id = CrateId::new("mock_crate".to_owned(), "0.1.0".to_owned());
+        context.crates.insert(
+            crate_id.clone(),
+            CrateContext {
+                name: crate_id.name,
+                version: crate_id.version,
+                targets: vec![Rule::Binary(mock_target_attributes())],
+                additive_build_file_content: Some(
+                    "# Hello World from additive section!".to_owned(),
+                ),
+                ..CrateContext::default()
+            },
+        );
+
+        let renderer = Renderer::new(mock_render_config());
+        let output = renderer.render(&context).unwrap();
+
+        let build_file_content = output
+            .get(&PathBuf::from("BUILD.mock_crate-0.1.0.bazel"))
+            .unwrap();
+
+        assert!(build_file_content.contains("# Hello World from additive section!"));
+    }
 }

--- a/tools/cargo_bazel/src/rendering/templates/crate_build_file.j2
+++ b/tools/cargo_bazel/src/rendering/templates/crate_build_file.j2
@@ -35,7 +35,7 @@ package(default_visibility = ["//visibility:public"])
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
-{%- if crate.extra_build_contents %}
-# Extra Build Contents
-{{ crate.extra_build_contents }}
+{%- if crate.additive_build_file_content %}
+# Additive BUILD file content
+{{ crate.additive_build_file_content }}
 {%- endif %}


### PR DESCRIPTION
Now users can write [buildifier](https://github.com/bazelbuild/buildtools/tree/4.2.5/buildifier) enforced files which will be added to the BUILD file generated for an associated crate.