### PR TITLE
Fixed platform label templates not rendering custom labels

### DIFF
--- a/tools/cargo_bazel/src/rendering/templates/partials/crate/aliases.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/crate/aliases.j2
@@ -4,7 +4,7 @@ selects.with_or({
         # {{ cfg }}
         (
             {%- for triple in context.conditions[cfg] %}
-            "@rules_rust//rust/platform:{{ triple }}",
+            "{{ platform_label(triple = triple) }}",
             {%- endfor %}
         ): {
             {%- for dep in values %}

--- a/tools/cargo_bazel/src/rendering/templates/partials/crate/deps.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/crate/deps.j2
@@ -10,7 +10,7 @@
         # {{ cfg }}
         (
             {%- for triple in context.conditions[cfg] %}
-            "@rules_rust//rust/platform:{{ triple }}",
+            "{{ platform_label(triple = triple) }}",
             {%- endfor %}
         ): [
             {%- for dep in values %}

--- a/tools/cargo_bazel/src/rendering/templates/partials/starlark/selectable_list.j2
+++ b/tools/cargo_bazel/src/rendering/templates/partials/starlark/selectable_list.j2
@@ -9,7 +9,7 @@
         # {{ cfg }}
         (
             {%- for triple in context.conditions[cfg] %}
-            "@rules_rust//rust/platform:{{ triple }}",
+            "{{ platform_label(triple = triple) }}",
             {%- endfor %}
         ): [
             {%- for val in values %}


### PR DESCRIPTION
This fixes some issues where `render_config.platforms_template` would be ignored when BUILD files were being rendered.