### PR TITLE
Improved error messaging

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -140,7 +140,9 @@ impl LockGenerator {
         };
 
         if !output.status.success() {
-            bail!(format!("Failed to generate lockfile: {:?}", output))
+            eprintln!("{}", String::from_utf8_lossy(&output.stdout));
+            eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+            bail!(format!("Failed to generate lockfile: {}", output.status))
         }
 
         cargo_lock::Lockfile::load(&generated_lockfile_path).context(format!(


### PR DESCRIPTION
This change updates error messages to be more human readable.

With the following diff applied
```diff
diff --git a/examples/cargo_aliases/Cargo.toml b/examples/cargo_aliases/Cargo.toml
index e49f1bd..783c094 100644
--- a/examples/cargo_aliases/Cargo.toml
+++ b/examples/cargo_aliases/Cargo.toml
@@ -17,5 +17,8 @@ value-bag = "=1.0.0-alpha.7"
 names = "=0.12.0"
 pinned_names = { package = "names", git = "https://github.com/fnichol/names.git", rev = "534b1cd239fb57933616f3d25ae258bdf708811d" }

+r2d2_sqlite = "=0.18.0"
+rusqlite = "=0.26.3"
+
 [dev-dependencies]
 env_logger = "0.9.0"
```

Errors have been updated from 
```
INFO: Repository 'cargo_aliases' used the following cache hits instead of downloading the corresponding file.
 * Hash 'ce7df004afd70413789c3aad2adc0a07225e0c1361780b924b3e809d1d978ca2' for file:/private/var/tmp/_bazel_user/c4900dc498759a5aae30fdfe5c69c114/execroot/cargo_bazel/bazel-out/darwin-fastbuild/bin/tests/examples.runfiles/cargo_bazel/cargo_bazel_bin
If the definition of 'cargo_aliases' was updated, verify that the hashes were also updated.
ERROR: An error occurred during the fetch of repository 'cargo_aliases':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/crates_repository.bzl", line 59, column 50, in _crates_repository_impl
		metadata_path = splice_workspace_manifest(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/splicing_utils.bzl", line 193, column 12, in splice_workspace_manifest
		execute(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/common_utils.bzl", line 39, column 13, in execute
		fail(_EXECUTE_ERROR_MESSAGE.format(
Error in fail: Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------
Error: Failed to generate lockfile: Output { status: ExitStatus(unix_wait_status(25856)), stdout: "", stderr: "    Updating crates.io index\n    Updating git repository `https://github.com/fnichol/names.git`\nerror: failed to select a version for `libsqlite3-sys`.\n    ... required by package `rusqlite v0.26.3`\n    ... which satisfies dependency `rusqlite = \"=0.26.3\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nversions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0\n\nthe package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:\npackage `libsqlite3-sys v0.22.2`\n    ... which satisfies dependency `libsqlite3-sys = \"^0.22.2\"` of package `rusqlite v0.25.4`\n    ... which satisfies dependency `rusqlite = \"^0.25\"` of package `r2d2_sqlite v0.18.0`\n    ... which satisfies dependency `r2d2_sqlite = \"=0.18.0\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nOnly one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.\n\nfailed to select a version for `libsqlite3-sys` which could resolve this conflict\n" }

ERROR: Error fetching repository: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/crates_repository.bzl", line 59, column 50, in _crates_repository_impl
		metadata_path = splice_workspace_manifest(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/splicing_utils.bzl", line 193, column 12, in splice_workspace_manifest
		execute(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/common_utils.bzl", line 39, column 13, in execute
		fail(_EXECUTE_ERROR_MESSAGE.format(
Error in fail: Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------
Error: Failed to generate lockfile: Output { status: ExitStatus(unix_wait_status(25856)), stdout: "", stderr: "    Updating crates.io index\n    Updating git repository `https://github.com/fnichol/names.git`\nerror: failed to select a version for `libsqlite3-sys`.\n    ... required by package `rusqlite v0.26.3`\n    ... which satisfies dependency `rusqlite = \"=0.26.3\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nversions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0\n\nthe package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:\npackage `libsqlite3-sys v0.22.2`\n    ... which satisfies dependency `libsqlite3-sys = \"^0.22.2\"` of package `rusqlite v0.25.4`\n    ... which satisfies dependency `rusqlite = \"^0.25\"` of package `r2d2_sqlite v0.18.0`\n    ... which satisfies dependency `r2d2_sqlite = \"=0.18.0\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nOnly one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.\n\nfailed to select a version for `libsqlite3-sys` which could resolve this conflict\n" }

ERROR: no such package '@cargo_aliases//': Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------
Error: Failed to generate lockfile: Output { status: ExitStatus(unix_wait_status(25856)), stdout: "", stderr: "    Updating crates.io index\n    Updating git repository `https://github.com/fnichol/names.git`\nerror: failed to select a version for `libsqlite3-sys`.\n    ... required by package `rusqlite v0.26.3`\n    ... which satisfies dependency `rusqlite = \"=0.26.3\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nversions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0\n\nthe package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:\npackage `libsqlite3-sys v0.22.2`\n    ... which satisfies dependency `libsqlite3-sys = \"^0.22.2\"` of package `rusqlite v0.25.4`\n    ... which satisfies dependency `rusqlite = \"^0.25\"` of package `r2d2_sqlite v0.18.0`\n    ... which satisfies dependency `r2d2_sqlite = \"=0.18.0\"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`\nOnly one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.\n\nfailed to select a version for `libsqlite3-sys` which could resolve this conflict\n" }
```
to 
```
INFO: Repository 'cargo_aliases' used the following cache hits instead of downloading the corresponding file.
 * Hash '926e6aa01c731504d5486ce68387f343d07a483abbc00b2609deaf1f4986bde5' for file:/private/var/tmp/_bazel_user/c4900dc498759a5aae30fdfe5c69c114/execroot/cargo_bazel/bazel-out/darwin-fastbuild/bin/tests/examples.runfiles/cargo_bazel/cargo_bazel_bin
If the definition of 'cargo_aliases' was updated, verify that the hashes were also updated.
ERROR: An error occurred during the fetch of repository 'cargo_aliases':
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/crates_repository.bzl", line 59, column 50, in _crates_repository_impl
		metadata_path = splice_workspace_manifest(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/splicing_utils.bzl", line 193, column 12, in splice_workspace_manifest
		execute(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/common_utils.bzl", line 39, column 13, in execute
		fail(_EXECUTE_ERROR_MESSAGE.format(
Error in fail: Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------

    Updating crates.io index
    Updating git repository `https://github.com/fnichol/names.git`
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `rusqlite v0.26.3`
    ... which satisfies dependency `rusqlite = "=0.26.3"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
versions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.22.2`
    ... which satisfies dependency `libsqlite3-sys = "^0.22.2"` of package `rusqlite v0.25.4`
    ... which satisfies dependency `rusqlite = "^0.25"` of package `r2d2_sqlite v0.18.0`
    ... which satisfies dependency `r2d2_sqlite = "=0.18.0"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict

Error: Failed to generate lockfile: exit status: 101

ERROR: Error fetching repository: Traceback (most recent call last):
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/crates_repository.bzl", line 59, column 50, in _crates_repository_impl
		metadata_path = splice_workspace_manifest(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/splicing_utils.bzl", line 193, column 12, in splice_workspace_manifest
		execute(
	File "/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_bazel/private/common_utils.bzl", line 39, column 13, in execute
		fail(_EXECUTE_ERROR_MESSAGE.format(
Error in fail: Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------

    Updating crates.io index
    Updating git repository `https://github.com/fnichol/names.git`
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `rusqlite v0.26.3`
    ... which satisfies dependency `rusqlite = "=0.26.3"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
versions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.22.2`
    ... which satisfies dependency `libsqlite3-sys = "^0.22.2"` of package `rusqlite v0.25.4`
    ... which satisfies dependency `rusqlite = "^0.25"` of package `r2d2_sqlite v0.18.0`
    ... which satisfies dependency `r2d2_sqlite = "=0.18.0"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict

Error: Failed to generate lockfile: exit status: 101

ERROR: no such package '@cargo_aliases//': Command [/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel, "splice", "--workspace-dir", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing, "--splicing-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/splicing_manifest.json, "--extra-manifests-manifest", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/extra_manifests_manifest.json, "--cargo", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/cargo, "--rustc", /private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/rust_darwin_x86_64/bin/rustc] failed with exit code 1.
STDOUT ------------------------------------------------------------------------

STDERR ------------------------------------------------------------------------

    Updating crates.io index
    Updating git repository `https://github.com/fnichol/names.git`
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `rusqlite v0.26.3`
    ... which satisfies dependency `rusqlite = "=0.26.3"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
versions that meet the requirements `^0.23.0` are: 0.23.2, 0.23.1, 0.23.0

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.22.2`
    ... which satisfies dependency `libsqlite3-sys = "^0.22.2"` of package `rusqlite v0.25.4`
    ... which satisfies dependency `rusqlite = "^0.25"` of package `r2d2_sqlite v0.18.0`
    ... which satisfies dependency `r2d2_sqlite = "=0.18.0"` of package `aliases v0.1.0 (/private/var/tmp/_bazel_user/7e078dc78807b9435edc17d0cd068cb9/external/cargo_aliases/cargo-bazel-splicing)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libsqlite3-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict

Error: Failed to generate lockfile: exit status: 101
```
